### PR TITLE
Optimize Dragon test backend lifecycle with module-scoped fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,33 @@
 
 ## [Unreleased]
 
-- Removed ThreadPoolExecutor wait approach (`_wait_executor`) attribute, streamlining concurrency management.
-- Added `disable_batch_submission` boolean parameter to `DragonExecutionBackendV3.__init__` and `create` methods, allowing configuration of task submission strategy.
-- Introduced `_monitored_batches` dictionary and `_batch_monitor_thread` to manage and monitor active task batches.
-- Replaced the `_wait_for_batch` method with a new `_monitor_loop` (running in a dedicated thread) and `_process_batch_results` helper, implementing a polling-based mechanism for task completion.
-- Modified `_async_init` to start the `_batch_monitor_thread` during backend initialization.
-- Updated `submit_tasks` to support conditional task submission: tasks can now be submitted as individual batches (stream mode) or a single combined batch, based on the `_disable_batch_submission` flag.
-- Adjusted the `shutdown` method to properly manage the lifecycle of the new `_batch_monitor_thread`.
+### Changed
+
+- Optimized Dragon backend tests by using module-scoped fixtures, reusing a single backend instance per Dragon version (V1, V2, V3) across all tests instead of creating/destroying one per test.
+
+## [0.1.2] - 2026-02-16
+
+### Fixed
+
+- Fixed project URLs in `pyproject.toml` to point to the correct GitHub repository.
+- Removed Python 3.8 classifier (package requires Python >= 3.9).
+
+## [0.1.1] - 2026-02-16
+
+### Fixed
+
+- Fixed `ImportError` when installing `rhapsody-py` without optional backends (Dragon, Dask, RADICAL-Pilot). Optional backend imports in `backends/__init__.py` are now wrapped in `try/except`.
+
+## [0.1.0] - 2025-02-16
+
+### Added
+
+- Initial PyPI release as `rhapsody-py` (import name: `rhapsody`).
+- Execution backends: Concurrent (built-in), Dask, RADICAL-Pilot, Dragon (V1, V2, V3).
+- Inference backend: Dragon-VLLM for LLM serving on HPC.
+- Task API: `ComputeTask` for executables/functions, `AITask` for LLM inference.
+- Session API for task submission, monitoring, and lifecycle management.
+- Backend discovery and registry system.
+- Removed ThreadPoolExecutor wait approach (`_wait_executor`), streamlining concurrency management.
+- Added `disable_batch_submission` parameter to `DragonExecutionBackendV3` for configurable task submission strategy.
+- Introduced polling-based batch monitoring with `_monitor_loop` and `_process_batch_results`.


### PR DESCRIPTION
Reuse Dragon backend instances across tests by changing fixture scope from function to module, reducing 45 backend startups/shutdowns to 3 (one per dragon_v1, dragon_v2, dragon_v3). Use pytest_asyncio.fixture with loop_scope=module for async fixture compatibility.

This should cut down the time to finish the tests by at least 70%