### PR TITLE
Feature/migrate dragonv3 api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- `DragonExecutionBackendV3`: migrated to the Dragon batch.py streaming pipeline. Tasks submitted via `session.submit_tasks()` are dispatched individually by a continuously running background thread — there is no compile or start step.
+- `DragonExecutionBackendV3`: accepts two new constructor parameters: `num_nodes` (total nodes) and `pool_nodes` (nodes per worker pool), forwarded directly to `Batch()`.
+- `DragonExecutionBackendV3.fence()`: new method that delegates to `batch.fence()`, allowing callers to wait for all in-flight tasks submitted by this client to complete.
+- `DragonExecutionBackendV3.create_ddict()`: new helper that creates a Dragon `DDict` instance directly from the backend.
+- `DragonExecutionBackendV3._deliver_result()` / `_deliver_failure()`: internal helpers that centralise result callback dispatch and cancellation checks, eliminating duplicated logic in the monitor loop.
+- Result monitoring uses `Task.get(block=False)` / `TaskNotReadyError` from `dragon.workflows.batch` — one `_monitored_batches` entry per individual task (was one entry per compiled batch).
 - `ConcurrentExecutionBackend`: regular (synchronous) functions are now executed correctly in both `ThreadPoolExecutor` and `ProcessPoolExecutor`. Previously, all function tasks were dispatched via `asyncio.run(func(...))`, which raised `ValueError` for non-coroutine callables. The executor now detects `asyncio.iscoroutinefunction` and calls sync functions directly.
 - `Session` / `TaskStateManager`: task futures now propagate exceptions on failure. Previously all futures were resolved with `set_result(task)` regardless of outcome. Failures now resolve as:
     - Function task raises → original exception propagated via `fut.set_exception(exc)`.
@@ -44,6 +50,10 @@
 
 ### Breaking Changes
 
+- **`DragonExecutionBackendV3`**: removed `num_workers`, `disable_background_batching`, and `disable_batch_submission` constructor parameters. These were incompatible with the new streaming pipeline — the Dragon batch always runs in streaming mode and worker counts are controlled via `num_nodes` / `pool_nodes`. Migration:
+    - `DragonExecutionBackendV3(num_workers=16)` → `DragonExecutionBackendV3(num_nodes=4, pool_nodes=2)` (or simply omit both to let Dragon decide)
+    - `DragonExecutionBackendV3(disable_batch_submission=True)` → remove (streaming is now always on)
+    - `DragonExecutionBackendV3(disable_background_batching=True)` → remove
 - **`ComputeTask` and `AITask`**: removed `ranks`, `memory`, `gpu`, `cpu_threads`, and `environment` parameters. These fields were never consumed by any execution backend — they were silently ignored, creating a misleading API. Resource requirements are now backend-specific and must be passed via `task_backend_specific_kwargs`. Migration:
   - `ComputeTask(executable=..., gpu=2)` → `ComputeTask(executable=..., task_backend_specific_kwargs={"resources": {"GPU": 2}})` (Dask) or `task_backend_specific_kwargs={"process_template": {"gpu": 2}}` (Dragon V3)
   - `ComputeTask(executable=..., environment={"K": "V"})` → `ComputeTask(executable=..., task_backend_specific_kwargs={"env": {"K": "V"}})` (Concurrent/Dask)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@
 - `DragonExecutionBackendV3`: accepts two new constructor parameters: `num_nodes` (total nodes) and `pool_nodes` (nodes per worker pool), forwarded directly to `Batch()`.
 - `DragonExecutionBackendV3.fence()`: new method that delegates to `batch.fence()`, allowing callers to wait for all in-flight tasks submitted by this client to complete.
 - `DragonExecutionBackendV3.create_ddict()`: new helper that creates a Dragon `DDict` instance directly from the backend.
-- `DragonExecutionBackendV3._deliver_result()` / `_deliver_failure()`: internal helpers that centralise result callback dispatch and cancellation checks, eliminating duplicated logic in the monitor loop.
-- Result monitoring uses `Task.get(block=False)` / `TaskNotReadyError` from `dragon.workflows.batch` — one `_monitored_batches` entry per individual task (was one entry per compiled batch).
+- `DragonExecutionBackendV3._deliver_result()` / `_deliver_failure()`: internal helpers that centralise result callback dispatch and cancellation checks, eliminating duplicated logic in the monitor loop. Both now expose `stdout`, `stderr`, and the full Dragon traceback string to the task description so callers can inspect execution output without polling side-effects.
+- `DragonExecutionBackendV3` result monitoring reads directly from `Batch.results_ddict` (the same distributed dict Dragon workers write to) instead of going through the `Task` object.
+- `DragonExecutionBackendV3._cancelled_tasks` converted from `list` to `set`: O(1) membership checks and automatic deduplication. Cancelled UIDs are now removed from the set once the monitor loop processes the task, preventing unbounded growth.
+- `DragonExecutionBackendV3._task_registry` entries are now removed atomically (via `dict.pop`) on result or failure delivery, eliminating unbounded registry growth for long-running sessions.
 - `ConcurrentExecutionBackend`: regular (synchronous) functions are now executed correctly in both `ThreadPoolExecutor` and `ProcessPoolExecutor`. Previously, all function tasks were dispatched via `asyncio.run(func(...))`, which raised `ValueError` for non-coroutine callables. The executor now detects `asyncio.iscoroutinefunction` and calls sync functions directly.
 - `Session` / `TaskStateManager`: task futures now propagate exceptions on failure. Previously all futures were resolved with `set_result(task)` regardless of outcome. Failures now resolve as:
     - Function task raises → original exception propagated via `fut.set_exception(exc)`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@
 - `DragonExecutionBackendV3`: accepts two new constructor parameters: `num_nodes` (total nodes) and `pool_nodes` (nodes per worker pool), forwarded directly to `Batch()`.
 - `DragonExecutionBackendV3.fence()`: new method that delegates to `batch.fence()`, allowing callers to wait for all in-flight tasks submitted by this client to complete.
 - `DragonExecutionBackendV3.create_ddict()`: new helper that creates a Dragon `DDict` instance directly from the backend.
-- `DragonExecutionBackendV3._deliver_result()` / `_deliver_failure()`: internal helpers that centralise result callback dispatch and cancellation checks, eliminating duplicated logic in the monitor loop. Both now expose `stdout`, `stderr`, and the full Dragon traceback string to the task description so callers can inspect execution output without polling side-effects.
-- `DragonExecutionBackendV3` result monitoring reads directly from `Batch.results_ddict` (the same distributed dict Dragon workers write to) instead of going through the `Task` object.
+- `DragonExecutionBackendV3._deliver_batch()`: replaces `_deliver_result` / `_deliver_failure`. All tasks that complete within a single monitor sweep are collected into a list and delivered to the asyncio event loop in **one** `call_soon_threadsafe` call instead of one per task — reducing cross-thread wakeups from O(tasks) to O(sweeps).
+- `DragonExecutionBackendV3` result monitoring reads directly from `Batch.results_ddict` (the same distributed dict Dragon workers write to) instead of going through the `Task` object. The membership check and value read are now a single `try/except KeyError` operation, eliminating the redundant `__contains__` network round-trip (was two DDict RTTs per ready task, now one).
+- `DragonExecutionBackendV3`: monitor thread now starts lazily on first `submit_tasks()` call instead of at `_async_init` time, eliminating the idle-spin phase while tasks are being built and registered.
 - `DragonExecutionBackendV3._cancelled_tasks` converted from `list` to `set`: O(1) membership checks and automatic deduplication. Cancelled UIDs are now removed from the set once the monitor loop processes the task, preventing unbounded growth.
 - `DragonExecutionBackendV3._task_registry` entries are now removed atomically (via `dict.pop`) on result or failure delivery, eliminating unbounded registry growth for long-running sessions.
 - `ConcurrentExecutionBackend`: regular (synchronous) functions are now executed correctly in both `ThreadPoolExecutor` and `ProcessPoolExecutor`. Previously, all function tasks were dispatched via `asyncio.run(func(...))`, which raised `ValueError` for non-coroutine callables. The executor now detects `asyncio.iscoroutinefunction` and calls sync functions directly.
@@ -32,6 +33,26 @@
 - `shell=True` for executable tasks via `task_backend_specific_kwargs={"shell": True}`.
 - `DaskExecutionBackend._check_resources_satisfiable()`: pre-submit check that immediately fails tasks with unsatisfiable resource constraints instead of hanging indefinitely. Function tasks set `task.exception`; executable tasks set `task.stderr` and `task.exit_code = 1`.
 - Integration tests for Dask backend: end-to-end sync/async/executable task execution, cluster injection (cluster and client), and resource constraint failure behavior.
+
+### Performance
+
+- `DragonExecutionBackendV3._monitor_loop`: eliminated redundant `Batch.results_ddict.__contains__` check — each ready task previously required two distributed DDict network round-trips (membership test + value read); now a single `try/except KeyError` read is used, saving ~570µs per task on HPC interconnects (~5.7s for 10K tasks).
+- `DragonExecutionBackendV3._monitor_loop`: monitor thread now starts lazily at first `submit_tasks()` call instead of at backend initialisation, eliminating ~1.2s of idle spinning while tasks are being built.
+- `DragonExecutionBackendV3._deliver_batch`: cross-thread wakeups reduced from O(tasks) to O(sweeps) — all completions found in a single sweep are batched into one `call_soon_threadsafe` call (~0.78s saved for 10K tasks).
+- `DragonExecutionBackendV3`: removed per-task `logger.debug` calls from the monitor hot path, eliminating 10K f-string allocations per run (29ms at 10K tasks, scales linearly).
+- `TaskStateManager`: removed `_task_states` shadow dict — task state is now read directly from `task["state"]` (single source of truth), eliminating one dict write per task completion.
+- `TaskStateManager._update_task_impl`: `_task_futures` entries are now removed via `dict.pop` on resolution, preventing unbounded memory growth at scale.
+- `Session`: removed history recording (`task["history"]` timestamps) — two `time.time()` syscalls and two dict writes per task eliminated.
+- `Session.get_statistics`: method removed entirely; it depended on history timestamps and iterated all tasks on every call.
+
+Measured on 2 nodes / 128 workers (HPC), 10K function tasks:
+
+| | Run 1 | Run 2 | Run 3 | Run 4 |
+|---|---|---|---|---|
+| Dragon batch only | 9.82s | 10.92s | 9.99s | 10.08s |
+| RHAPSODY + Dragon batch | 10.50s | 12.17s | 9.92s | 11.18s |
+
+RHAPSODY overhead reduced from ~7.8s (before) to ≤1.3s (after) — within normal run-to-run variance of the Dragon batch itself.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ from rhapsody.backends import DragonExecutionBackendV3, DragonVllmInferenceBacke
 
 async def main():
     # Initialize backends
-    hpc_backend = await DragonExecutionBackendV3(name="hpc", num_workers=128)
+    hpc_backend = await DragonExecutionBackendV3(name="hpc")
     ai_backend = await DragonVllmInferenceBackend(name="vllm", model="Qwen2.5-7B")
 
     # Create session with multiple backends

--- a/docs/getting-started/advanced-usage.md
+++ b/docs/getting-started/advanced-usage.md
@@ -254,7 +254,6 @@ async def dragon_demo():
     # Initialize the Dragon backend (optimized for HPC)
     # V3 uses native Dragon Batch for high-performance wait/callbacks
     dragon_be = await DragonExecutionBackendV3(
-        num_workers=8,
         name="dragon_hpc"
     )
 
@@ -507,7 +506,7 @@ async def main():
         await asyncio.gather(*futures)
 
         for t in tasks:
-            result = t.return_value if t.function else t.stdout.strip()
+            result = t.return_value if t.function else t.stdout
             print(f"Task {t.uid}: {t.state} (output: {result})")
 
 if __name__ == "__main__":
@@ -596,7 +595,7 @@ async def run():
             await session.wait_tasks(tasks)
 
         for t in tasks:
-            result = t.return_value if t.function else t.stdout.strip()
+            result = t.return_value if t.function else t.stdout
             print(f"{t.uid}: {t.state} -> {result}")
 ```
 

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -66,29 +66,23 @@ from rhapsody.backends import DragonExecutionBackendV3
 
 backend = DragonExecutionBackendV3(
     name="dragon",
-    num_workers=16,               # Total worker processes
-    disable_telemetry=False,       # Enable/disable Dragon telemetry
-    disable_background_batching=False, # Enable/disable background monitoring
-    disable_batch_submission=False # Toggle batch vs individual submission
+    num_nodes=4,            # Total nodes for the worker pool (optional)
+    pool_nodes=2,           # Nodes per worker pool (optional)
+    disable_telemetry=False,  # Enable/disable Dragon telemetry
 )
 ```
 
-!!! note "Batch vs. Stream Submission"
-    The `disable_batch_submission` parameter controls how tasks are sent to the Dragon runtime:
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `name` | `str` | `"dragon"` | Backend identifier used for task routing |
+| `num_nodes` | `int` | `None` | Total number of nodes; forwarded to `Batch(num_nodes=...)` |
+| `pool_nodes` | `int` | `None` | Nodes per worker pool; forwarded to `Batch(pool_nodes=...)` |
+| `disable_telemetry` | `bool` | `False` | Disable Dragon internal telemetry |
 
-    - **Batch Mode** (`False`): High throughput. Groups tasks into a single multi-task batch.
-    - **Stream Mode** (`True`): Individual monitoring. Each task is submitted and tracked as a separate Dragon batch.
-
-    ```python
-    # Batch Mode (Recommended for many small tasks)
-    backend = await DragonExecutionBackendV3(disable_batch_submission=False)
-    await session.submit_tasks([t1, t2]) # Single submission
-
-    # Stream Mode (Better for isolated task tracking)
-    backend = await DragonExecutionBackendV3(disable_batch_submission=True)
-    await session.submit_tasks([t1, t2]) # Two separate submissions
-    ```
-
+!!! note "Streaming pipeline"
+    `DragonExecutionBackendV3` uses Dragon's streaming batch pipeline — tasks submitted via
+    `session.submit_tasks()` are dispatched individually by a continuously running background
+    thread. There is no compile or start step; tasks begin executing as soon as they are submitted.
 
 !!! note "Dragon Versions"
     While `DragonExecutionBackendV3` is recommended for most users and will be always maintained, V1 and V2 are also available for legacy compatibility.

--- a/docs/hpc-machines/ncsa-delta.md
+++ b/docs/hpc-machines/ncsa-delta.md
@@ -60,7 +60,7 @@ dragon <script.py>
 
 ## Example
 
-This example runs 32 MPI jobs concurrently using RHAPSODY's `Session` API with the `DragonExecutionBackendV3`. Each job gets a random number of ranks (between 2 and 32), all scheduled across the 2 allocated nodes. Worker count is derived automatically from the available CPUs.
+This example runs 32 MPI jobs concurrently using RHAPSODY's `Session` API with the `DragonExecutionBackendV3`. Each job gets a random number of ranks (between 2 and 32), all scheduled across the 2 allocated nodes. Worker count is determined automatically by Dragon from the allocation.
 
 ```python title="mpi-rhapsody.py"
 import asyncio
@@ -71,7 +71,6 @@ import time
 import rhapsody
 from rhapsody.api import ComputeTask, Session
 from rhapsody.backends import DragonExecutionBackendV3
-from dragon.native.machine import cpu_count
 
 rhapsody.enable_logging(level=logging.DEBUG)
 
@@ -97,9 +96,8 @@ async def main():
     njobs = 32
     sleepsecs = 2
     maxranks = 32
-    numworkers = cpu_count() // 2
 
-    backend = await DragonExecutionBackendV3(num_workers=numworkers)
+    backend = await DragonExecutionBackendV3()
     session = Session(backends=[backend])
 
     print("--- Submitting Tasks ---")
@@ -142,12 +140,10 @@ dragon mpi-rhapsody.py
     2026-03-25 23:07:36,938 | DEBUG    | [api_setup] | got handshake
     2026-03-25 23:07:36,938 | INFO     | [api_setup] | debug entry hooked
     2026-03-25 23:07:36,942 | DEBUG    | [dragon.native.queue] | Created queue {self!r}
-    2026-03-25 23:07:37,648 | INFO     | [rhapsody.backends.execution.dragon] | DragonExecutionBackendV3: 128 workers, 2 managers, disable_batch_submission=False
+    2026-03-25 23:07:37,648 | INFO     | [rhapsody.backends.execution.dragon] | DragonExecutionBackendV3: 128 workers, 2 managers
     2026-03-25 23:07:37,648 | DEBUG    | [rhapsody.backends.execution.dragon] | Starting Dragon backend V3 async initialization...
     2026-03-25 23:07:37,648 | DEBUG    | [rhapsody.backends.execution.dragon] | Registering backend states...
     2026-03-25 23:07:37,649 | DEBUG    | [rhapsody.backends.execution.dragon] | Registering task states...
-    2026-03-25 23:07:37,649 | DEBUG    | [rhapsody.backends.execution.dragon] | Starting Dragon batch monitor loop (polling mode)
-    2026-03-25 23:07:37,649 | DEBUG    | [rhapsody.backends.execution.dragon] | Dragon monitor thread started during initialization
     2026-03-25 23:07:37,650 | INFO     | [rhapsody.backends.execution.dragon] | Dragon backend V3 fully initialized and ready
     2026-03-25 23:07:37,650 | DEBUG    | [rhapsody.api.session] | Setting up backend callback for'dragon' with Session 'session.0000'
     2026-03-25 23:07:37,650 | DEBUG    | [rhapsody.api.session] | Registered backend 'dragon' with Session 'session.0000'

--- a/docs/hpc-machines/perlmutter.md
+++ b/docs/hpc-machines/perlmutter.md
@@ -91,7 +91,6 @@ import multiprocessing as mp
 import rhapsody
 from rhapsody.api import AITask, ComputeTask, Session
 from rhapsody.backends import DragonExecutionBackendV3, DragonVllmInferenceBackend
-from dragon.native.machine import cpu_count
 
 rhapsody.enable_logging(level=logging.INFO)
 
@@ -161,9 +160,7 @@ def fine_tune(simulation_outputs: list):
 async def main():
     mp.set_start_method("dragon")
 
-    numworkers = cpu_count() // 2
-
-    execution_backend = await DragonExecutionBackendV3(num_workers=numworkers)
+    execution_backend = await DragonExecutionBackendV3()
 
     inference_backend = await DragonVllmInferenceBackend(
         config_file="config.yaml",

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ from rhapsody.backends import DragonExecutionBackendV3
 
 async def main():
     # 1. Initialize session with a backend
-    backend = await DragonExecutionBackendV3(num_workers=2048)
+    backend = await DragonExecutionBackendV3()
     async with Session(backends=[backend]) as session:
 
         # 2. Define a task

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -50,7 +50,7 @@ async def main():
     mp.set_start_method("dragon")
 
     # Initialize execution backend for compute tasks
-    execution_backend = await DragonExecutionBackendV3(num_workers=4)
+    execution_backend = await DragonExecutionBackendV3()
 
     # Initialize inference backend for AI tasks
     inference_backend = DragonVllmInferenceBackend(
@@ -348,7 +348,7 @@ backend = await DaskExecutionBackend()
 
 # Dragon HPC
 from rhapsody.backends import DragonExecutionBackendV3
-backend = await DragonExecutionBackendV3(num_workers=2048)
+backend = await DragonExecutionBackendV3()
 
 # Create workflow with chosen backend
 flow = await WorkflowEngine.create(backend=backend)

--- a/examples/02-workload-heterogeneous.py
+++ b/examples/02-workload-heterogeneous.py
@@ -67,7 +67,7 @@ async def main():
         await asyncio.gather(*futures)  # or tasks both works
 
         for t in tasks:
-            result = t.return_value if t.function else t.stdout.strip()
+            result = t.return_value if t.function else t.stdout
             print(f"Task {t.uid}: {t.state} (output: {result})")
 
 

--- a/examples/03-workload-ai-hpc.py
+++ b/examples/03-workload-ai-hpc.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 async def main():
     mp.set_start_method("dragon")
 
-    execution_backend = await DragonExecutionBackendV3(num_workers=4)
+    execution_backend = await DragonExecutionBackendV3()
 
     inference_backend = DragonVllmInferenceBackend(
         config_file="config.yaml",

--- a/src/rhapsody/api/session.py
+++ b/src/rhapsody/api/session.py
@@ -3,11 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-import time
-from collections import Counter
-from collections import defaultdict
 from typing import TYPE_CHECKING
-from typing import Any
 
 from rhapsody.api.errors import TaskExecutionError
 
@@ -28,7 +24,6 @@ class TaskStateManager:
 
     def __init__(self):
         self._task_futures: dict[str, asyncio.Future] = {}
-        self._task_states: dict[str, str] = {}
         self._terminal_states = set()  # Will be populated by backends
         self._lock = asyncio.Lock()
         self._loop: asyncio.AbstractEventLoop | None = None
@@ -37,7 +32,7 @@ class TaskStateManager:
         """Bind an event loop to the manager for thread-safe updates."""
         self._loop = loop
 
-    def update_task(self, task: dict | BaseTask, state: str, **kwargs: Any) -> None:
+    def update_task(self, task: dict | BaseTask, state: str, **kwargs: object) -> None:
         """Update task state and notify waiters (thread-safe)."""
         if self._loop and not self._loop.is_closed():
             self._loop.call_soon_threadsafe(self._update_task_impl, task, state)
@@ -53,22 +48,14 @@ class TaskStateManager:
     def _update_task_impl(self, task: dict | BaseTask, state: str) -> None:
         """Actual update logic, expected to run on the event loop."""
         uid = task["uid"]
-        now = time.time()
 
-        # Update the task object in-place (Single Source of Truth update)
+        # Update the task object in-place (Single Source of Truth)
         task["state"] = state
-
-        # Telemetry: Record transition history
-        if "history" not in task:
-            task["history"] = {}
-        task["history"][state] = now
-
-        self._task_states[uid] = state
 
         # If terminal, notify waiters
         if state in self._terminal_states:
             if uid in self._task_futures:
-                fut = self._task_futures[uid]
+                fut = self._task_futures.pop(uid)
                 if not fut.done():
                     exc = task.get("exception")
                     exit_code = task.get("exit_code")
@@ -97,7 +84,7 @@ class TaskStateManager:
                 self._task_futures[uid] = asyncio.Future()
 
             # If already done before we started waiting, resolve immediately
-            if self._task_states.get(uid) in self._terminal_states:
+            if task.get("state") in self._terminal_states:
                 exc = task.get("exception")
                 exit_code = task.get("exit_code")
                 if isinstance(exc, BaseException):
@@ -185,10 +172,8 @@ class Session:
         if not self.backends:
             raise RuntimeError("No backends configured in Session")
 
-        # Map backends by name for fast lookup
-        tasks_by_backend = defaultdict(list)
-
         # Group tasks by their explicit backend target
+        tasks_by_backend: dict[str, list] = {}
         futures = []
         for task in tasks:
             uid = task["uid"]
@@ -199,12 +184,6 @@ class Session:
             if hasattr(task, "bind_future"):
                 task.bind_future(fut)
             futures.append(fut)
-
-            # Mark submission time
-            if "history" not in task:
-                task["history"] = {}
-            if "submitted" not in task["history"]:
-                task["history"]["submitted"] = time.time()
 
             # Routing decision
             target_name = task.get("backend")
@@ -220,7 +199,7 @@ class Session:
                     f"Available backends: {available}"
                 )
 
-            tasks_by_backend[target_name].append(task)
+            tasks_by_backend.setdefault(target_name, []).append(task)
 
         # Submit each group to its respective backend concurrently
         submission_tasks = []
@@ -276,50 +255,6 @@ class Session:
             )
 
         return tasks
-
-    def get_statistics(self) -> dict[str, Any]:
-        """Get session-wide delivery and performance statistics.
-
-        Returns:
-            Dictionary containing task counts, success rates, and latencies.
-        """
-        stats: dict[str, Any] = {
-            "counts": Counter(),
-            "latencies": {
-                "total": [],
-                "queue": [],
-                "execution": [],
-            },
-            "summary": {},
-        }
-
-        for task in self._tasks.values():
-            state = task.get("state", "UNKNOWN")
-            stats["counts"][state] += 1
-
-            history = task.get("history", {})
-            submitted = history.get("submitted")
-            running = history.get("RUNNING")
-            done = history.get("DONE") or history.get("FAILED") or history.get("CANCELED")
-
-            if submitted and done:
-                stats["latencies"]["total"].append(done - submitted)
-
-            if submitted and running:
-                stats["latencies"]["queue"].append(running - submitted)
-
-            if running and done:
-                stats["latencies"]["execution"].append(done - running)
-
-        # Calculate averages for summary
-        for key, values in stats["latencies"].items():
-            if values:
-                stats["summary"][f"avg_{key}"] = sum(values) / len(values)
-            else:
-                stats["summary"][f"avg_{key}"] = 0.0
-
-        stats["summary"]["total_tasks"] = len(self._tasks)
-        return stats
 
     async def close(self) -> None:
         """Shutdown all backends."""

--- a/src/rhapsody/backends/execution/dragon.py
+++ b/src/rhapsody/backends/execution/dragon.py
@@ -3234,7 +3234,7 @@ class DragonExecutionBackendV3(BaseBackend):
         self.logger.debug("Dragon batch monitor loop stopped")
 
     def _deliver_result(
-        self, uid: str, result: Any, stdout: str | None, stderr: str | None
+        self, uid: str, result: Any, stdout: Optional[str], stderr: Optional[str]
     ) -> None:
         """Trigger DONE callback for a successfully completed task."""
         task_info = self._task_registry.pop(uid, None)
@@ -3252,7 +3252,12 @@ class DragonExecutionBackendV3(BaseBackend):
         self._callback_func(task_desc, "DONE")
 
     def _deliver_failure(
-        self, uid: str, exc: Exception, tb: str | None, stdout: str | None, stderr: str | None
+        self,
+        uid: str,
+        exc: Exception,
+        tb: Optional[str],
+        stdout: Optional[str],
+        stderr: Optional[str],
     ) -> None:
         """Trigger FAILED callback for a task that raised an exception."""
         task_info = self._task_registry.pop(uid, None)

--- a/src/rhapsody/backends/execution/dragon.py
+++ b/src/rhapsody/backends/execution/dragon.py
@@ -3188,7 +3188,7 @@ class DragonExecutionBackendV3(BaseBackend):
         return self
 
     def _monitor_loop(self):
-        """Single thread to monitor all active tasks using Task.get(block=False).
+        """Single thread to monitor all active tasks.
 
         Tasks are auto-dispatched by the Batch background thread the moment they are created. This
         loop polls each registered task non-blocking and fires callbacks when results arrive.

--- a/src/rhapsody/backends/execution/dragon.py
+++ b/src/rhapsody/backends/execution/dragon.py
@@ -3134,7 +3134,7 @@ class DragonExecutionBackendV3(BaseBackend):
         self._task_registry: dict[str, Any] = {}
         self._task_states = TaskStateMapperV3()
         self._initialized = False
-        self._cancelled_tasks = []
+        self._cancelled_tasks: set[str] = set()
         self._monitored_batches = {}
         self._batch_monitor_thread = None
 
@@ -3209,22 +3209,20 @@ class DragonExecutionBackendV3(BaseBackend):
                     if tuid not in self._monitored_batches:
                         continue
 
-                    batch_task, uid = self._monitored_batches[tuid]
-
-                    try:
-                        # Non-blocking check: raises TaskNotReadyError if not done yet
-                        result = batch_task.get(block=False)
-                        self._deliver_result(uid, result)
-                        self._monitored_batches.pop(tuid)
-                        self.logger.debug(f"Task {uid} complete")
-
-                    except TaskNotReadyError:
-                        # Task not done yet, continue to next one
+                    # Check DDict directly — avoids exception overhead on the common not-ready path
+                    # and gives us the full (result, tb, raised, stdout, stderr) tuple.
+                    if tuid not in self.batch.results_ddict:
                         continue
-                    except Exception as e:
-                        self._deliver_failure(uid, e)
-                        self._monitored_batches.pop(tuid)
-                        self.logger.exception(f"Error retrieving result for task {uid}: {e}")
+
+                    batch_task, uid = self._monitored_batches.pop(tuid)
+                    result, tb, raised, stdout, stderr = self.batch.results_ddict[tuid]
+
+                    if raised:
+                        self._deliver_failure(uid, result, tb, stdout, stderr)
+                        self.logger.debug(f"Task {uid} failed")
+                    else:
+                        self._deliver_result(uid, result, stdout, stderr)
+                        self.logger.debug(f"Task {uid} complete")
 
                 # Small sleep after each full sweep to prevent tight loop
                 time.sleep(0.005)
@@ -3235,23 +3233,39 @@ class DragonExecutionBackendV3(BaseBackend):
 
         self.logger.debug("Dragon batch monitor loop stopped")
 
-    def _deliver_result(self, uid: str, result: Any) -> None:
+    def _deliver_result(
+        self, uid: str, result: Any, stdout: str | None, stderr: str | None
+    ) -> None:
         """Trigger DONE callback for a successfully completed task."""
-        task_info = self._task_registry.get(uid)
-        if not task_info or uid in self._cancelled_tasks:
+        task_info = self._task_registry.pop(uid, None)
+        if not task_info:
+            return
+        if uid in self._cancelled_tasks:
+            self._cancelled_tasks.discard(uid)
             return
         task_desc = task_info["description"]
         task_desc["return_value"] = result
+        if stdout:
+            task_desc["stdout"] = stdout
+        if stderr:
+            task_desc["stderr"] = stderr
         self._callback_func(task_desc, "DONE")
 
-    def _deliver_failure(self, uid: str, exc: Exception) -> None:
+    def _deliver_failure(
+        self, uid: str, exc: Exception, tb: str | None, stdout: str | None, stderr: str | None
+    ) -> None:
         """Trigger FAILED callback for a task that raised an exception."""
-        task_info = self._task_registry.get(uid)
-        if not task_info or uid in self._cancelled_tasks:
+        task_info = self._task_registry.pop(uid, None)
+        if not task_info:
+            return
+        if uid in self._cancelled_tasks:
+            self._cancelled_tasks.discard(uid)
             return
         task_desc = task_info["description"]
         task_desc["exception"] = exc
-        task_desc["stderr"] = str(exc)
+        task_desc["stderr"] = tb if tb else str(exc)
+        if stdout:
+            task_desc["stdout"] = stdout
         self._callback_func(task_desc, "FAILED")
 
     async def submit_tasks(self, tasks: list[dict]) -> None:
@@ -3439,7 +3453,7 @@ class DragonExecutionBackendV3(BaseBackend):
         # the asyncflow that the task is cancelled so not to block the flow
         task = self._task_registry[uid]["description"]
         self._callback_func(task, "CANCELED")
-        self._cancelled_tasks.append(uid)
+        self._cancelled_tasks.add(uid)
 
         return True
 

--- a/src/rhapsody/backends/execution/dragon.py
+++ b/src/rhapsody/backends/execution/dragon.py
@@ -43,7 +43,7 @@ try:
     from dragon.native.process_group import ProcessGroup
     from dragon.native.queue import Queue
     from dragon.telemetry import Telemetry
-    from dragon.workflows.batch import Batch
+    from dragon.workflows.batch import Batch, TaskNotReadyError
 
 except ImportError:  # pragma: no cover - environment without Dragon
     dragon = None
@@ -56,6 +56,7 @@ except ImportError:  # pragma: no cover - environment without Dragon
     System = None
     Policy = None
     Batch = None
+    TaskNotReadyError = None
     Event = None
     Telemetry = None
     AccVendor = None
@@ -3081,10 +3082,11 @@ class DragonExecutionBackendV2(BaseBackend):
 
 
 class DragonExecutionBackendV3(BaseBackend):
-    """Fast Dragon Batch integration using .wait() in threads.
+    """Dragon Batch backend using the streaming pipeline model.
 
-    No polling! Each compiled batch gets a thread that calls .wait() and triggers callbacks when
-    done. This is the Dragon-native way.
+    Tasks submitted via batch.function()/process()/job() are auto-dispatched by the Batch
+    background thread. A single monitor thread polls each task with Task.get(block=False)
+    and fires callbacks when results become available in the DDict.
 
     Note on working directory:
         DragonExecutionBackendV3 does not support a backend-level working directory.
@@ -3109,10 +3111,9 @@ class DragonExecutionBackendV3(BaseBackend):
 
     def __init__(
         self,
-        num_workers: Optional[int] = None,
-        disable_background_batching: bool = False,
+        num_nodes: Optional[int] = None,
+        pool_nodes: Optional[int] = None,
         disable_telemetry: bool = False,
-        disable_batch_submission: bool = False,
         name: Optional[str] = "dragon",
     ):
         if not Batch:
@@ -3122,9 +3123,9 @@ class DragonExecutionBackendV3(BaseBackend):
 
         self.logger = _get_logger()
         self.batch = Batch(
-            num_workers=num_workers or 0,
+            num_nodes=num_nodes,
+            pool_nodes=pool_nodes,
             disable_telem=disable_telemetry,
-            disable_background_batching=disable_background_batching,
         )
 
         self._backend_state = BackendMainStates.INITIALIZED
@@ -3133,8 +3134,6 @@ class DragonExecutionBackendV3(BaseBackend):
         self._task_states = TaskStateMapperV3()
         self._initialized = False
         self._cancelled_tasks = []
-        self._disable_batch_submission = disable_batch_submission
-        # compiled_tuid -> (compiled_task, list_of_tasks)
         self._monitored_batches = {}
         self._batch_monitor_thread = None
 
@@ -3142,7 +3141,7 @@ class DragonExecutionBackendV3(BaseBackend):
 
         self.logger.info(
             f"DragonExecutionBackendV3: {self.batch.num_workers} workers, "
-            f"{self.batch.num_managers} managers, disable_batch_submission={self._disable_batch_submission}"
+            f"{self.batch.num_managers} managers"
         )
 
     def __await__(self):
@@ -3188,10 +3187,10 @@ class DragonExecutionBackendV3(BaseBackend):
         return self
 
     def _monitor_loop(self):
-        """Single thread to monitor all active batches using public wait() API.
+        """Single thread to monitor all active tasks using Task.get(block=False).
 
-        This uses a polling approach with a small timeout (0.01s) to avoid busy-waiting while
-        maintaining low latency.
+        Tasks are auto-dispatched by the Batch background thread the moment they are created.
+        This loop polls each registered task non-blocking and fires callbacks when results arrive.
         """
         self.logger.debug("Starting Dragon batch monitor loop (polling mode)")
 
@@ -3201,7 +3200,7 @@ class DragonExecutionBackendV3(BaseBackend):
                 batch_tuids = list(self._monitored_batches.keys())
 
                 if not batch_tuids:
-                    # No active batches, sleep briefly to avoid high CPU
+                    # No active tasks, sleep briefly to avoid high CPU
                     time.sleep(0.01)
                     continue
 
@@ -3209,28 +3208,24 @@ class DragonExecutionBackendV3(BaseBackend):
                     if tuid not in self._monitored_batches:
                         continue
 
-                    compiled_tasks, task_uids = self._monitored_batches[tuid]
+                    batch_task, uid = self._monitored_batches[tuid]
 
                     try:
-                        # Public API wait with minimal timeout
-                        # Returns quickly if not done, returns instantly if done
-                        compiled_tasks.wait(timeout=0.01)
-
-                        # If we reach here, batch is finished (or raised an internal error)
-                        self.logger.debug(f"Batch {tuid} complete, processing results")
-                        self._process_batch_results(compiled_tasks, task_uids)
+                        # Non-blocking check: raises TaskNotReadyError if not done yet
+                        result = batch_task.get(block=False)
+                        self._deliver_result(uid, result)
                         self._monitored_batches.pop(tuid)
+                        self.logger.debug(f"Task {uid} complete")
 
-                    except TimeoutError:
-                        # Batch not done yet, continue to next one
+                    except TaskNotReadyError:
+                        # Task not done yet, continue to next one
                         continue
                     except Exception as e:
-                        self.logger.exception(f"Error while waiting for batch {tuid}: {e}")
-                        # Even on error, we should process results to trigger FAILED callbacks
-                        self._process_batch_results(compiled_tasks, task_uids)
+                        self._deliver_failure(uid, e)
                         self._monitored_batches.pop(tuid)
+                        self.logger.exception(f"Error retrieving result for task {uid}: {e}")
 
-                # Small sleep after each full sweep to prevent tight loop if all batches were polled
+                # Small sleep after each full sweep to prevent tight loop
                 time.sleep(0.005)
 
             except Exception as e:
@@ -3239,43 +3234,24 @@ class DragonExecutionBackendV3(BaseBackend):
 
         self.logger.debug("Dragon batch monitor loop stopped")
 
-    def _process_batch_results(self, compiled_tasks, task_uids):
-        """Extract results from a finished batch and trigger callbacks."""
-        for uid in task_uids:
-            task_info = self._task_registry.get(uid)
-            if not task_info or uid in self._cancelled_tasks:
-                continue
+    def _deliver_result(self, uid: str, result: Any) -> None:
+        """Trigger DONE callback for a successfully completed task."""
+        task_info = self._task_registry.get(uid)
+        if not task_info or uid in self._cancelled_tasks:
+            return
+        task_desc = task_info["description"]
+        task_desc["return_value"] = result
+        self._callback_func(task_desc, "DONE")
 
-            batch_task = task_info["batch_task"]
-            task_desc = task_info["description"]
-
-            try:
-                # Use small timeout for safety, but data is guaranteed to be local now
-                try:
-                    stdout = batch_task.stdout.get(timeout=0.01)
-                    task_desc["stdout"] = stdout if stdout is not None else ""
-                except Exception:
-                    task_desc["stdout"] = ""
-
-                try:
-                    result = batch_task.result.get(timeout=0.01)
-                    task_desc["return_value"] = result
-                    self._callback_func(task_desc, "DONE")
-                except Exception as e:
-                    self.logger.exception(f"Task {uid} failed: {e}")
-                    task_desc["exception"] = e
-                    try:
-                        stderr = batch_task.stderr.get(timeout=0.01)
-                        task_desc["stderr"] = stderr if stderr else str(e)
-                    except Exception:
-                        task_desc["stderr"] = str(e)
-                    self._callback_func(task_desc, "FAILED")
-
-            except Exception as e:
-                self.logger.exception(f"Batch extraction failed for task {uid}: {e}")
-                task_desc["exception"] = e
-                task_desc["stderr"] = str(e)
-                self._callback_func(task_desc, "FAILED")
+    def _deliver_failure(self, uid: str, exc: Exception) -> None:
+        """Trigger FAILED callback for a task that raised an exception."""
+        task_info = self._task_registry.get(uid)
+        if not task_info or uid in self._cancelled_tasks:
+            return
+        task_desc = task_info["description"]
+        task_desc["exception"] = exc
+        task_desc["stderr"] = str(exc)
+        self._callback_func(task_desc, "FAILED")
 
     async def submit_tasks(self, tasks: list[dict]) -> None:
         """Submit tasks to the backend.
@@ -3304,23 +3280,12 @@ class DragonExecutionBackendV3(BaseBackend):
         if not batch_tasks_data:
             return
 
-        # Choose submission strategy
-        if self._disable_batch_submission:
-            # Stream mode: individual single-task batches
-            for uid, batch_task in batch_tasks_data:
-                compiled = self.batch.compile([batch_task])
-                tuid = compiled.core.tuid
-                self._monitored_batches[tuid] = (compiled, [uid])
-                compiled.start()
-            self.logger.info(f"Submitted {len(batch_tasks_data)} individual tasks in stream mode")
-        else:
-            # Batch mode: one multi-task batch
-            uids, btasks = map(list, zip(*batch_tasks_data))
-            compiled = self.batch.compile(btasks)
-            tuid = compiled.core.tuid
-            self._monitored_batches[tuid] = (compiled, uids)
-            compiled.start()
-            self.logger.info(f"Submitted {len(btasks)} tasks in a single batch")
+        # Tasks are already in-flight — the Batch background thread auto-dispatches them
+        # the moment they are created via batch.function()/process()/job().
+        # Register each task individually for result monitoring.
+        for uid, batch_task in batch_tasks_data:
+            self._monitored_batches[batch_task.uid] = (batch_task, uid)
+        self.logger.info(f"Submitted {len(batch_tasks_data)} tasks (streaming, auto-dispatched)")
 
     async def build_task(self, task: dict):
         """Translate AsyncFlow task to Dragon Batch task.
@@ -3522,22 +3487,22 @@ class DragonExecutionBackendV3(BaseBackend):
         self.batch.fence()
 
     def create_ddict(self, *args, **kwargs):
-        return self.batch.ddict(*args, **kwargs)
+        from dragon.data.ddict.ddict import DDict
+
+        return DDict(*args, **kwargs)
 
     @classmethod
     async def create(
         cls,
-        num_workers: Optional[int] = None,
-        disable_background_batching: bool = False,
+        num_nodes: Optional[int] = None,
+        pool_nodes: Optional[int] = None,
         disable_telemetry: bool = False,
-        disable_batch_submission: bool = False,
     ):
         """Create and initialize a DragonExecutionBackendV3."""
         backend = cls(
-            num_workers=num_workers,
-            disable_background_batching=disable_background_batching,
+            num_nodes=num_nodes,
+            pool_nodes=pool_nodes,
             disable_telemetry=disable_telemetry,
-            disable_batch_submission=disable_batch_submission,
         )
         return await backend
 

--- a/src/rhapsody/backends/execution/dragon.py
+++ b/src/rhapsody/backends/execution/dragon.py
@@ -3252,7 +3252,6 @@ class DragonExecutionBackendV3(BaseBackend):
                     task_desc["stderr"] = stderr
                 self._callback_func(task_desc, "DONE")
 
-
     async def submit_tasks(self, tasks: list[dict]) -> None:
         """Submit tasks to the backend.
 

--- a/src/rhapsody/backends/execution/dragon.py
+++ b/src/rhapsody/backends/execution/dragon.py
@@ -3137,6 +3137,7 @@ class DragonExecutionBackendV3(BaseBackend):
         self._cancelled_tasks: set[str] = set()
         self._monitored_batches = {}
         self._batch_monitor_thread = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
 
         self._shutdown_event = threading.Event()
 
@@ -3169,15 +3170,6 @@ class DragonExecutionBackendV3(BaseBackend):
                 self.logger.debug("Registering task states...")
                 StateMapper.register_backend_tasks_states_with_defaults(backend=self)
 
-                # Step 4: Start monitor thread
-                if self._batch_monitor_thread is None or not self._batch_monitor_thread.is_alive():
-                    self._shutdown_event.clear()
-                    self._batch_monitor_thread = threading.Thread(
-                        target=self._monitor_loop, name="dragon_monitor_loop", daemon=True
-                    )
-                    self._batch_monitor_thread.start()
-                    self.logger.debug("Dragon monitor thread started during initialization")
-
                 self._initialized = True
                 self.logger.info("Dragon backend V3 fully initialized and ready")
 
@@ -3205,24 +3197,22 @@ class DragonExecutionBackendV3(BaseBackend):
                     time.sleep(0.01)
                     continue
 
+                # Collect all completed tasks in this sweep, then deliver in one batch
+                completed = []
                 for tuid in batch_tuids:
                     if tuid not in self._monitored_batches:
                         continue
-
-                    # Check DDict directly — avoids exception overhead on the common not-ready path
-                    # and gives us the full (result, tb, raised, stdout, stderr) tuple.
-                    if tuid not in self.batch.results_ddict:
+                    # Single DDict read: KeyError means not ready yet (avoids redundant __contains__)
+                    try:
+                        result, tb, raised, stdout, stderr = self.batch.results_ddict[tuid]
+                    except KeyError:
                         continue
-
                     batch_task, uid = self._monitored_batches.pop(tuid)
-                    result, tb, raised, stdout, stderr = self.batch.results_ddict[tuid]
+                    completed.append((uid, result, tb, raised, stdout, stderr))
 
-                    if raised:
-                        self._deliver_failure(uid, result, tb, stdout, stderr)
-                        self.logger.debug(f"Task {uid} failed")
-                    else:
-                        self._deliver_result(uid, result, stdout, stderr)
-                        self.logger.debug(f"Task {uid} complete")
+                # One cross-thread wakeup for the entire sweep batch
+                if completed:
+                    self._loop.call_soon_threadsafe(self._deliver_batch, completed)
 
                 # Small sleep after each full sweep to prevent tight loop
                 time.sleep(0.005)
@@ -3233,45 +3223,35 @@ class DragonExecutionBackendV3(BaseBackend):
 
         self.logger.debug("Dragon batch monitor loop stopped")
 
-    def _deliver_result(
-        self, uid: str, result: Any, stdout: Optional[str], stderr: Optional[str]
-    ) -> None:
-        """Trigger DONE callback for a successfully completed task."""
-        task_info = self._task_registry.pop(uid, None)
-        if not task_info:
-            return
-        if uid in self._cancelled_tasks:
-            self._cancelled_tasks.discard(uid)
-            return
-        task_desc = task_info["description"]
-        task_desc["return_value"] = result
-        if stdout:
-            task_desc["stdout"] = stdout
-        if stderr:
-            task_desc["stderr"] = stderr
-        self._callback_func(task_desc, "DONE")
+    def _deliver_batch(self, completions: list) -> None:
+        """Deliver a batch of completed tasks. Runs on the asyncio event loop (via
+        call_soon_threadsafe).
 
-    def _deliver_failure(
-        self,
-        uid: str,
-        exc: Exception,
-        tb: Optional[str],
-        stdout: Optional[str],
-        stderr: Optional[str],
-    ) -> None:
-        """Trigger FAILED callback for a task that raised an exception."""
-        task_info = self._task_registry.pop(uid, None)
-        if not task_info:
-            return
-        if uid in self._cancelled_tasks:
-            self._cancelled_tasks.discard(uid)
-            return
-        task_desc = task_info["description"]
-        task_desc["exception"] = exc
-        task_desc["stderr"] = tb if tb else str(exc)
-        if stdout:
-            task_desc["stdout"] = stdout
-        self._callback_func(task_desc, "FAILED")
+        Called once per monitor sweep with all tasks that completed in that sweep, reducing cross-
+        thread wakeups from O(tasks) to O(sweeps).
+        """
+        for uid, result, tb, raised, stdout, stderr in completions:
+            task_info = self._task_registry.pop(uid, None)
+            if not task_info:
+                continue
+            if uid in self._cancelled_tasks:
+                self._cancelled_tasks.discard(uid)
+                continue
+            task_desc = task_info["description"]
+            if raised:
+                task_desc["exception"] = result
+                task_desc["stderr"] = tb if tb else str(result)
+                if stdout:
+                    task_desc["stdout"] = stdout
+                self._callback_func(task_desc, "FAILED")
+            else:
+                task_desc["return_value"] = result
+                if stdout:
+                    task_desc["stdout"] = stdout
+                if stderr:
+                    task_desc["stderr"] = stderr
+                self._callback_func(task_desc, "DONE")
+
 
     async def submit_tasks(self, tasks: list[dict]) -> None:
         """Submit tasks to the backend.
@@ -3285,6 +3265,18 @@ class DragonExecutionBackendV3(BaseBackend):
         if self._backend_state != BackendMainStates.RUNNING:
             self._backend_state = BackendMainStates.RUNNING
             self.logger.debug(f"Backend state set to: {self._backend_state.value}")
+
+        # Capture event loop for cross-thread batch delivery
+        if self._loop is None:
+            self._loop = asyncio.get_running_loop()
+
+        # Start monitor thread on first submission (lazy — avoids idle spin before tasks exist)
+        if self._batch_monitor_thread is None or not self._batch_monitor_thread.is_alive():
+            self._shutdown_event.clear()
+            self._batch_monitor_thread = threading.Thread(
+                target=self._monitor_loop, name="dragon_monitor_loop", daemon=True
+            )
+            self._batch_monitor_thread.start()
 
         # Build tasks
         batch_tasks_data = []

--- a/src/rhapsody/backends/execution/dragon.py
+++ b/src/rhapsody/backends/execution/dragon.py
@@ -44,7 +44,6 @@ try:
     from dragon.native.queue import Queue
     from dragon.telemetry import Telemetry
     from dragon.workflows.batch import Batch
-    from dragon.workflows.batch.batch import TaskNotReadyError
 
 except ImportError:  # pragma: no cover - environment without Dragon
     dragon = None
@@ -57,7 +56,6 @@ except ImportError:  # pragma: no cover - environment without Dragon
     System = None
     Policy = None
     Batch = None
-    TaskNotReadyError = None
     Event = None
     Telemetry = None
     AccVendor = None

--- a/src/rhapsody/backends/execution/dragon.py
+++ b/src/rhapsody/backends/execution/dragon.py
@@ -43,7 +43,8 @@ try:
     from dragon.native.process_group import ProcessGroup
     from dragon.native.queue import Queue
     from dragon.telemetry import Telemetry
-    from dragon.workflows.batch import Batch, TaskNotReadyError
+    from dragon.workflows.batch import Batch
+    from dragon.workflows.batch.batch import TaskNotReadyError
 
 except ImportError:  # pragma: no cover - environment without Dragon
     dragon = None
@@ -3189,8 +3190,8 @@ class DragonExecutionBackendV3(BaseBackend):
     def _monitor_loop(self):
         """Single thread to monitor all active tasks using Task.get(block=False).
 
-        Tasks are auto-dispatched by the Batch background thread the moment they are created.
-        This loop polls each registered task non-blocking and fires callbacks when results arrive.
+        Tasks are auto-dispatched by the Batch background thread the moment they are created. This
+        loop polls each registered task non-blocking and fires callbacks when results arrive.
         """
         self.logger.debug("Starting Dragon batch monitor loop (polling mode)")
 

--- a/tests/unit/test_backend_execution_dragon.py
+++ b/tests/unit/test_backend_execution_dragon.py
@@ -12,7 +12,7 @@ V3 integration tests — process_template / process_templates routing
 
 V3 unit tests — constructor and internal methods
     Verify the API surface introduced by the batch.py migration (new constructor
-    parameters, _deliver_result, _deliver_failure, fence delegation) with Batch
+    parameters, _deliver_batch, fence delegation) with Batch
     mocked out. No Dragon cluster is required for these tests.
 
 Run with:
@@ -83,6 +83,7 @@ def backend_v3():
         backend = DragonExecutionBackendV3()
 
     backend._callback_func = MagicMock()
+    backend._loop = asyncio.get_event_loop()
     return backend
 
 
@@ -609,43 +610,42 @@ def test_v3_constructor_rejects_removed_params():
             DragonExecutionBackendV3(disable_batch_submission=True)
 
 
-def test_v3_deliver_result_stores_value_and_fires_done(backend_v3):
-    """_deliver_result stores return_value on the task dict and fires the DONE callback."""
+def test_v3_deliver_batch_success_stores_value_and_fires_done(backend_v3):
+    """_deliver_batch stores return_value on the task dict and fires the DONE callback."""
     uid = "task.unit-done"
     task_desc = {"uid": uid}
     backend_v3._task_registry[uid] = {"uid": uid, "description": task_desc}
 
-    backend_v3._deliver_result(uid, result=42, stdout=None, stderr=None)
+    backend_v3._deliver_batch([(uid, 42, None, False, None, None)])
 
     assert task_desc["return_value"] == 42
     assert "stdout" not in task_desc
     assert "stderr" not in task_desc
     backend_v3._callback_func.assert_called_once_with(task_desc, "DONE")
-    # registry entry removed after delivery
     assert uid not in backend_v3._task_registry
 
 
-def test_v3_deliver_result_propagates_stdout_stderr(backend_v3):
-    """_deliver_result stores stdout/stderr on task_desc when non-empty."""
+def test_v3_deliver_batch_propagates_stdout_stderr(backend_v3):
+    """_deliver_batch stores stdout/stderr on task_desc when non-empty."""
     uid = "task.unit-done-out"
     task_desc = {"uid": uid}
     backend_v3._task_registry[uid] = {"uid": uid, "description": task_desc}
 
-    backend_v3._deliver_result(uid, result="ok", stdout="hello\n", stderr="warn\n")
+    backend_v3._deliver_batch([(uid, "ok", None, False, "hello\n", "warn\n")])
 
     assert task_desc["stdout"] == "hello\n"
     assert task_desc["stderr"] == "warn\n"
 
 
-def test_v3_deliver_failure_stores_exc_and_fires_failed(backend_v3):
-    """_deliver_failure stores the exception and stderr string, fires the FAILED callback."""
+def test_v3_deliver_batch_failure_stores_exc_and_fires_failed(backend_v3):
+    """_deliver_batch stores the exception and stderr string, fires the FAILED callback."""
     uid = "task.unit-failed"
     task_desc = {"uid": uid}
     backend_v3._task_registry[uid] = {"uid": uid, "description": task_desc}
     exc = RuntimeError("something went wrong")
 
-    # Without tb: stderr falls back to str(exc)
-    backend_v3._deliver_failure(uid, exc, tb=None, stdout=None, stderr=None)
+    # raised=True, tb=None: stderr falls back to str(exc)
+    backend_v3._deliver_batch([(uid, exc, None, True, None, None)])
 
     assert task_desc["exception"] is exc
     assert "something went wrong" in task_desc["stderr"]
@@ -653,35 +653,30 @@ def test_v3_deliver_failure_stores_exc_and_fires_failed(backend_v3):
     assert uid not in backend_v3._task_registry
 
 
-def test_v3_deliver_failure_prefers_traceback_over_str_exc(backend_v3):
-    """_deliver_failure uses Dragon's traceback string when available."""
+def test_v3_deliver_batch_prefers_traceback_over_str_exc(backend_v3):
+    """_deliver_batch uses Dragon's traceback string when available."""
     uid = "task.unit-failed-tb"
     task_desc = {"uid": uid}
     backend_v3._task_registry[uid] = {"uid": uid, "description": task_desc}
     exc = RuntimeError("boom")
     tb = "Traceback (most recent call last):\n  File ...\nRuntimeError: boom"
 
-    backend_v3._deliver_failure(uid, exc, tb=tb, stdout=None, stderr=None)
+    backend_v3._deliver_batch([(uid, exc, tb, True, None, None)])
 
     assert task_desc["stderr"] == tb
 
 
-def test_v3_cancelled_task_skips_both_callbacks(backend_v3):
-    """_deliver_result and _deliver_failure are no-ops for UIDs in _cancelled_tasks."""
+def test_v3_cancelled_task_skips_callback(backend_v3):
+    """_deliver_batch is a no-op for UIDs in _cancelled_tasks."""
     uid = "task.unit-cancelled"
     task_desc = {"uid": uid}
     backend_v3._task_registry[uid] = {"uid": uid, "description": task_desc}
     backend_v3._cancelled_tasks.add(uid)
 
-    backend_v3._deliver_result(uid, result=99, stdout=None, stderr=None)
-    # registry is popped on first call; re-register so _deliver_failure can also exercise guard
-    backend_v3._task_registry[uid] = {"uid": uid, "description": task_desc}
-    backend_v3._cancelled_tasks.add(uid)
-    backend_v3._deliver_failure(uid, RuntimeError("ignored"), tb=None, stdout=None, stderr=None)
+    backend_v3._deliver_batch([(uid, 99, None, False, None, None)])
 
     backend_v3._callback_func.assert_not_called()
     assert "return_value" not in task_desc
-    # uid cleaned out of _cancelled_tasks by both guards
     assert uid not in backend_v3._cancelled_tasks
 
 

--- a/tests/unit/test_backend_execution_dragon.py
+++ b/tests/unit/test_backend_execution_dragon.py
@@ -615,10 +615,26 @@ def test_v3_deliver_result_stores_value_and_fires_done(backend_v3):
     task_desc = {"uid": uid}
     backend_v3._task_registry[uid] = {"uid": uid, "description": task_desc}
 
-    backend_v3._deliver_result(uid, result=42)
+    backend_v3._deliver_result(uid, result=42, stdout=None, stderr=None)
 
     assert task_desc["return_value"] == 42
+    assert "stdout" not in task_desc
+    assert "stderr" not in task_desc
     backend_v3._callback_func.assert_called_once_with(task_desc, "DONE")
+    # registry entry removed after delivery
+    assert uid not in backend_v3._task_registry
+
+
+def test_v3_deliver_result_propagates_stdout_stderr(backend_v3):
+    """_deliver_result stores stdout/stderr on task_desc when non-empty."""
+    uid = "task.unit-done-out"
+    task_desc = {"uid": uid}
+    backend_v3._task_registry[uid] = {"uid": uid, "description": task_desc}
+
+    backend_v3._deliver_result(uid, result="ok", stdout="hello\n", stderr="warn\n")
+
+    assert task_desc["stdout"] == "hello\n"
+    assert task_desc["stderr"] == "warn\n"
 
 
 def test_v3_deliver_failure_stores_exc_and_fires_failed(backend_v3):
@@ -628,11 +644,26 @@ def test_v3_deliver_failure_stores_exc_and_fires_failed(backend_v3):
     backend_v3._task_registry[uid] = {"uid": uid, "description": task_desc}
     exc = RuntimeError("something went wrong")
 
-    backend_v3._deliver_failure(uid, exc)
+    # Without tb: stderr falls back to str(exc)
+    backend_v3._deliver_failure(uid, exc, tb=None, stdout=None, stderr=None)
 
     assert task_desc["exception"] is exc
     assert "something went wrong" in task_desc["stderr"]
     backend_v3._callback_func.assert_called_once_with(task_desc, "FAILED")
+    assert uid not in backend_v3._task_registry
+
+
+def test_v3_deliver_failure_prefers_traceback_over_str_exc(backend_v3):
+    """_deliver_failure uses Dragon's traceback string when available."""
+    uid = "task.unit-failed-tb"
+    task_desc = {"uid": uid}
+    backend_v3._task_registry[uid] = {"uid": uid, "description": task_desc}
+    exc = RuntimeError("boom")
+    tb = "Traceback (most recent call last):\n  File ...\nRuntimeError: boom"
+
+    backend_v3._deliver_failure(uid, exc, tb=tb, stdout=None, stderr=None)
+
+    assert task_desc["stderr"] == tb
 
 
 def test_v3_cancelled_task_skips_both_callbacks(backend_v3):
@@ -640,13 +671,18 @@ def test_v3_cancelled_task_skips_both_callbacks(backend_v3):
     uid = "task.unit-cancelled"
     task_desc = {"uid": uid}
     backend_v3._task_registry[uid] = {"uid": uid, "description": task_desc}
-    backend_v3._cancelled_tasks.append(uid)
+    backend_v3._cancelled_tasks.add(uid)
 
-    backend_v3._deliver_result(uid, result=99)
-    backend_v3._deliver_failure(uid, RuntimeError("ignored"))
+    backend_v3._deliver_result(uid, result=99, stdout=None, stderr=None)
+    # registry is popped on first call; re-register so _deliver_failure can also exercise guard
+    backend_v3._task_registry[uid] = {"uid": uid, "description": task_desc}
+    backend_v3._cancelled_tasks.add(uid)
+    backend_v3._deliver_failure(uid, RuntimeError("ignored"), tb=None, stdout=None, stderr=None)
 
     backend_v3._callback_func.assert_not_called()
     assert "return_value" not in task_desc
+    # uid cleaned out of _cancelled_tasks by both guards
+    assert uid not in backend_v3._cancelled_tasks
 
 
 def test_v3_fence_delegates_to_batch(backend_v3):

--- a/tests/unit/test_backend_execution_dragon.py
+++ b/tests/unit/test_backend_execution_dragon.py
@@ -583,10 +583,12 @@ def test_v3_constructor_accepts_new_params_and_forwards_to_batch():
     mock_batch.num_workers = 8
     mock_batch.num_managers = 1
 
-    with patch("rhapsody.backends.execution.dragon.Batch", return_value=mock_batch) as MockBatch:
+    with patch(
+        "rhapsody.backends.execution.dragon.Batch", return_value=mock_batch
+    ) as mock_batch_cls:
         backend = DragonExecutionBackendV3(num_nodes=4, pool_nodes=2, disable_telemetry=True)
 
-    MockBatch.assert_called_once_with(num_nodes=4, pool_nodes=2, disable_telem=True)
+    mock_batch_cls.assert_called_once_with(num_nodes=4, pool_nodes=2, disable_telem=True)
     assert backend.batch is mock_batch
 
 

--- a/tests/unit/test_backend_execution_dragon.py
+++ b/tests/unit/test_backend_execution_dragon.py
@@ -1,10 +1,27 @@
 """Tests for Dragon execution backends (V1, V2, V3) using Session.
 
-These tests focus on core features with minimal tasks (1-2 per test).
-Run with: dragon python -m pytest tests/unit/test_backend_execution_dragon.py -v
+Structure
+---------
+Shared behavior tests (1-15)
+    Parametrized across dragon_v1 / dragon_v2 / dragon_v3. Verify observable task
+    execution semantics that every Dragon backend must satisfy.
+
+V3 integration tests — process_template / process_templates routing
+    Use a dedicated ``session_v3`` fixture so only one V3 session is created,
+    rather than creating three parametrized sessions and skipping two.
+
+V3 unit tests — constructor and internal methods
+    Verify the API surface introduced by the batch.py migration (new constructor
+    parameters, _deliver_result, _deliver_failure, fence delegation) with Batch
+    mocked out. No Dragon cluster is required for these tests.
+
+Run with:
+    dragon python -m pytest tests/unit/test_backend_execution_dragon.py -v
 """
 
 import asyncio
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 import pytest_asyncio
@@ -13,8 +30,9 @@ from rhapsody import ComputeTask
 from rhapsody.api import Session
 from rhapsody.backends.discovery import get_backend
 
-# Skip all tests in this module if Dragon is not available
+# Skip the entire module when the Dragon runtime is not installed.
 pytest.importorskip("dragon", reason="Dragon is required for Dragon backend tests")
+
 
 # ============================================================================
 # Fixtures
@@ -23,17 +41,63 @@ pytest.importorskip("dragon", reason="Dragon is required for Dragon backend test
 
 @pytest.fixture(scope="module", params=["dragon_v1", "dragon_v2", "dragon_v3"])
 def backend_name(request):
-    """Parametrize tests across all Dragon backend versions."""
+    """Parametrize shared behavior tests across all Dragon backend versions."""
     return request.param
 
 
 @pytest_asyncio.fixture(scope="module", loop_scope="module")
 async def session(backend_name):
-    """Create a Session with Dragon backend, reused across all tests in the module."""
+    """Session with the parametrized Dragon backend, reused across shared tests."""
     backend_instance = await get_backend(backend_name)
     session_instance = Session(backends=[backend_instance])
     yield session_instance
     await session_instance.close()
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="module")
+async def session_v3():
+    """Session backed exclusively by DragonExecutionBackendV3.
+
+    Used by V3-specific tests so only one session is created instead of three.
+    """
+    backend_instance = await get_backend("dragon_v3")
+    session_instance = Session(backends=[backend_instance])
+    yield session_instance
+    await session_instance.close()
+
+
+@pytest.fixture
+def backend_v3():
+    """DragonExecutionBackendV3 with Batch fully mocked — no Dragon cluster required.
+
+    Suitable for unit tests that verify constructor wiring, internal callback helpers, and method
+    delegation without running actual Dragon workers.
+    """
+    from rhapsody.backends.execution.dragon import DragonExecutionBackendV3
+
+    mock_batch = MagicMock()
+    mock_batch.num_workers = 16
+    mock_batch.num_managers = 2
+
+    with patch("rhapsody.backends.execution.dragon.Batch", return_value=mock_batch):
+        backend = DragonExecutionBackendV3()
+
+    backend._callback_func = MagicMock()
+    return backend
+
+
+def _make_task_dict(fn, args=(), kwargs=None, backend_specific=None):
+    """Build a minimal task dict in the format expected by build_task."""
+    import uuid
+
+    return {
+        "uid": f"task.test-{uuid.uuid4().hex[:8]}",
+        "function": fn,
+        "args": list(args),
+        "kwargs": kwargs or {},
+        "name": "test",
+        "task_backend_specific_kwargs": backend_specific or {},
+    }
 
 
 # ============================================================================
@@ -44,14 +108,11 @@ async def session(backend_name):
 @pytest.mark.asyncio(loop_scope="module")
 async def test_single_executable(session):
     """Test executing a single shell command task."""
-    task = ComputeTask(
-        executable="echo", arguments=["Hello Dragon"], task_backend_specific_kwargs={"shell": True}
-    )
+    task = ComputeTask(executable="echo", arguments=["Hello Dragon"])
 
     await session.submit_tasks([task])
     results = await session.wait_tasks([task])
 
-    # wait_tasks returns list of tasks (updated in-place)
     assert results[0].uid.startswith("task.")
     assert results[0].state == "DONE"
     assert "Hello Dragon" in results[0].get("stdout", "")
@@ -67,7 +128,6 @@ async def test_single_function(session):
     """Test executing a single Python function task."""
 
     async def simple_function(x: int) -> int:
-        """Simple async function for testing."""
         return x * 2
 
     task = ComputeTask(function=simple_function, args=(21,))
@@ -95,8 +155,6 @@ async def test_task_with_args(session):
 
     assert results[0].state == "DONE"
     stdout = results[0].get("stdout", "")
-    # Note: echo output might process args differently depending on shell execution
-    # but typically "arg1 arg2 arg3"
     assert "arg1" in stdout and "arg2" in stdout and "arg3" in stdout
 
 
@@ -108,9 +166,7 @@ async def test_task_with_args(session):
 @pytest.mark.asyncio(loop_scope="module")
 async def test_task_failure(session):
     """Test that failed tasks are properly reported."""
-    task = ComputeTask(
-        executable="/bin/false"  # Command that always fails
-    )
+    task = ComputeTask(executable="/bin/false")
 
     await session.submit_tasks([task])
     results = await session.wait_tasks([task])
@@ -128,7 +184,6 @@ async def test_function_exception(session):
     """Test that function exceptions are properly handled."""
 
     async def failing_function():
-        """Function that raises an exception."""
         raise ValueError("Intentional test failure")
 
     task = ComputeTask(function=failing_function, args=())
@@ -149,12 +204,8 @@ async def test_function_exception(session):
 async def test_two_independent_tasks(session):
     """Test executing two independent tasks in parallel."""
     tasks = [
-        ComputeTask(
-            executable="echo", arguments=["Task A"], task_backend_specific_kwargs={"shell": True}
-        ),
-        ComputeTask(
-            executable="echo", arguments=["Task B"], task_backend_specific_kwargs={"shell": True}
-        ),
+        ComputeTask(executable="echo", arguments=["Task A"]),
+        ComputeTask(executable="echo", arguments=["Task B"]),
     ]
 
     await session.submit_tasks(tasks)
@@ -199,7 +250,6 @@ async def test_function_return_value(session):
     """Test that function return values are properly captured."""
 
     async def compute_function(a: int, b: int) -> dict:
-        """Function that returns a complex value."""
         return {"sum": a + b, "product": a * b, "inputs": [a, b]}
 
     task = ComputeTask(function=compute_function, args=(5, 7))
@@ -246,22 +296,14 @@ async def test_stdout_capture(session):
 @pytest.mark.asyncio(loop_scope="module")
 async def test_task_cancellation(session):
     """Test cancelling a task before completion."""
-    # Long-running task
     task = ComputeTask(executable="/bin/sleep", arguments=["10"])
 
     await session.submit_tasks([task])
-    await asyncio.sleep(0.5)  # Let task start
+    await asyncio.sleep(0.5)
 
-    # Cancel the task using the backend directly (via session mostly for simplicity but API allows backend access)
-    # Note: Session doesn't expose cancel_task directly yet, we invoke it on backend
-    # MVP: Assuming single backend in session
     backend = next(iter(session.backends.values()))
     cancelled = await backend.cancel_task(task.uid)
     assert cancelled is True
-
-    # Wait a bit and verify task was updated (optional, depends on backend propagation)
-    await asyncio.sleep(1.0)
-    # We don't assert state here as it may vary between backends immediately
 
 
 # ============================================================================
@@ -271,20 +313,13 @@ async def test_task_cancellation(session):
 
 @pytest.mark.asyncio(loop_scope="module")
 async def test_backend_state(session):
-    """Test backend state tracking."""
+    """Test backend state is queryable and non-null."""
     backend = next(iter(session.backends.values()))
     state = await backend.state()
     assert state is not None
 
-    # Submit a task
-    task = ComputeTask(
-        executable="echo", arguments=["test"], task_backend_specific_kwargs={"shell": True}
-    )
-
+    task = ComputeTask(executable="echo", arguments=["test"])
     await session.submit_tasks([task])
-    state_running = await backend.state()
-    # assert state_running == "RUNNING" # This is flaky depending on timing
-
     await session.wait_tasks([task])
 
 
@@ -296,20 +331,14 @@ async def test_backend_state(session):
 @pytest.mark.asyncio(loop_scope="module")
 async def test_sequential_submissions(session):
     """Test submitting tasks in multiple batches."""
-    # First batch
-    task1 = ComputeTask(
-        executable="echo", arguments=["Batch 1"], task_backend_specific_kwargs={"shell": True}
-    )
+    task1 = ComputeTask(executable="echo", arguments=["Batch 1"])
 
     await session.submit_tasks([task1])
     results1 = await session.wait_tasks([task1])
     assert results1[0].state == "DONE"
     assert "Batch 1" in results1[0].get("stdout", "")
 
-    # Second batch
-    task2 = ComputeTask(
-        executable="echo", arguments=["Batch 2"], task_backend_specific_kwargs={"shell": True}
-    )
+    task2 = ComputeTask(executable="echo", arguments=["Batch 2"])
 
     await session.submit_tasks([task2])
     results2 = await session.wait_tasks([task2])
@@ -327,7 +356,6 @@ async def test_function_with_kwargs(session):
     """Test function execution with keyword arguments."""
 
     async def function_with_kwargs(x: int, y: int = 10, z: int = 20) -> int:
-        """Function that uses keyword arguments."""
         return x + y + z
 
     task = ComputeTask(function=function_with_kwargs, args=(5,), kwargs={"y": 15, "z": 25})
@@ -359,12 +387,8 @@ async def test_empty_task_list(session):
 async def test_task_uid_uniqueness(session):
     """Test that auto-generated UIDs are unique."""
     tasks = [
-        ComputeTask(
-            executable="echo", arguments=["Task 1"], task_backend_specific_kwargs={"shell": True}
-        ),
-        ComputeTask(
-            executable="echo", arguments=["Task 2"], task_backend_specific_kwargs={"shell": True}
-        ),
+        ComputeTask(executable="echo", arguments=["Task 1"]),
+        ComputeTask(executable="echo", arguments=["Task 2"]),
     ]
 
     await session.submit_tasks(tasks)
@@ -377,20 +401,13 @@ async def test_task_uid_uniqueness(session):
 
 
 # ============================================================================
-# Test: cwd via process_template
+# V3 integration tests — per-task cwd and process_template routing
 # ============================================================================
 
 
 @pytest.mark.asyncio(loop_scope="module")
-async def test_executable_with_cwd_via_process_template(session, backend_name):
-    """Test that cwd is honoured when set via process_template in task_backend_specific_kwargs.
-
-    Only applicable to DragonExecutionBackendV3 — V1 and V2 use a backend-level working_directory
-    and do not support per-task cwd via process_template.
-    """
-    if backend_name in ("dragon_v1", "dragon_v2"):
-        pytest.skip(f"{backend_name} does not support per-task cwd via process_template")
-
+async def test_executable_with_cwd_via_process_template(session_v3):
+    """Test that cwd is honoured when set via process_template (V3 only)."""
     import sys
 
     task = ComputeTask(
@@ -399,46 +416,19 @@ async def test_executable_with_cwd_via_process_template(session, backend_name):
         task_backend_specific_kwargs={"process_template": {"cwd": "/tmp"}},
     )
 
-    await session.submit_tasks([task])
-    results = await session.wait_tasks([task])
+    await session_v3.submit_tasks([task])
+    results = await session_v3.wait_tasks([task])
 
     assert results[0].state == "DONE"
     assert "/tmp" in results[0].get("stdout", "")
 
 
-# ============================================================================
-# Tests: ProcessTemplate spec validation (V3 only)
-# These tests verify that process_template/process_templates dicts are correctly
-# translated into ProcessTemplate objects and passed to Dragon's batch API.
-# ============================================================================
-
-
-def _make_task_dict(fn, args=(), kwargs=None, backend_specific=None):
-    """Build a minimal task dict matching the format expected by build_task."""
-    import uuid
-
-    return {
-        "uid": f"task.test-{uuid.uuid4().hex[:8]}",
-        "function": fn,
-        "args": list(args),
-        "kwargs": kwargs or {},
-        "name": "test",
-        "task_backend_specific_kwargs": backend_specific or {},
-    }
-
-
 @pytest.mark.asyncio(loop_scope="module")
-async def test_process_template_cwd_built_and_passed(session, backend_name):
+async def test_process_template_cwd_built_and_passed(session_v3):
     """Test A: process_template with cwd produces a ProcessTemplate with correct cwd."""
-    if backend_name in ("dragon_v1", "dragon_v2"):
-        pytest.skip(f"{backend_name} does not support per-task process_template")
-
-    from unittest.mock import MagicMock
-    from unittest.mock import patch
-
     from dragon.native.process import ProcessTemplate
 
-    backend = session.backends["dragon"]
+    backend = session_v3.backends["dragon"]
     captured = []
 
     def capture(pt, **kw):
@@ -457,18 +447,12 @@ async def test_process_template_cwd_built_and_passed(session, backend_name):
 
 
 @pytest.mark.asyncio(loop_scope="module")
-async def test_process_template_policy_gpu_affinity_built_and_passed(session, backend_name):
+async def test_process_template_policy_gpu_affinity_built_and_passed(session_v3):
     """Test B: process_template with policy(gpu_affinity) produces ProcessTemplate with correct policy."""
-    if backend_name in ("dragon_v1", "dragon_v2"):
-        pytest.skip(f"{backend_name} does not support per-task process_template")
-
-    from unittest.mock import MagicMock
-    from unittest.mock import patch
-
     from dragon.infrastructure.policy import Policy
     from dragon.native.process import ProcessTemplate
 
-    backend = session.backends["dragon"]
+    backend = session_v3.backends["dragon"]
     captured = []
 
     def capture(pt, **kw):
@@ -489,19 +473,13 @@ async def test_process_template_policy_gpu_affinity_built_and_passed(session, ba
 
 
 @pytest.mark.asyncio(loop_scope="module")
-async def test_process_template_empty_dict_uses_process_mode(session, backend_name):
-    """Test C: process_template={} (empty dict) still routes to batch.process(), not batch.function().
+async def test_process_template_empty_dict_uses_process_mode(session_v3):
+    """Test C: process_template={} still routes to batch.process(), not batch.function().
 
-    Regression test for Bug 1: truthiness check `elif process_template_config:` would
-    silently fall through on empty dict; `is not None` fix ensures Priority 2 wins.
+    Regression test: a truthiness check on the dict silently falls through on an
+    empty dict; the ``is not None`` guard in build_task prevents this.
     """
-    if backend_name in ("dragon_v1", "dragon_v2"):
-        pytest.skip(f"{backend_name} does not support per-task process_template")
-
-    from unittest.mock import MagicMock
-    from unittest.mock import patch
-
-    backend = session.backends["dragon"]
+    backend = session_v3.backends["dragon"]
     process_calls = []
     function_calls = []
 
@@ -528,17 +506,11 @@ async def test_process_template_empty_dict_uses_process_mode(session, backend_na
 
 
 @pytest.mark.asyncio(loop_scope="module")
-async def test_process_templates_list_built_and_passed_to_job(session, backend_name):
+async def test_process_templates_list_built_and_passed_to_job(session_v3):
     """Test D: process_templates list produces correct (nranks, ProcessTemplate) tuples for batch.job()."""
-    if backend_name in ("dragon_v1", "dragon_v2"):
-        pytest.skip(f"{backend_name} does not support per-task process_templates")
-
-    from unittest.mock import MagicMock
-    from unittest.mock import patch
-
     from dragon.native.process import ProcessTemplate
 
-    backend = session.backends["dragon"]
+    backend = session_v3.backends["dragon"]
     captured_args = []
 
     def capture_job(templates, **kw):
@@ -563,18 +535,13 @@ async def test_process_templates_list_built_and_passed_to_job(session, backend_n
 
 
 @pytest.mark.asyncio(loop_scope="module")
-async def test_process_template_combined_spec_policy_cwd_args(session, backend_name):
+async def test_process_template_combined_spec_policy_cwd_args(session_v3):
     """Test E: process_template with policy + cwd all land on the ProcessTemplate correctly."""
-    if backend_name in ("dragon_v1", "dragon_v2"):
-        pytest.skip(f"{backend_name} does not support per-task process_template")
-
-    from unittest.mock import MagicMock
-    from unittest.mock import patch
-
+    import cloudpickle
     from dragon.infrastructure.policy import Policy
     from dragon.native.process import ProcessTemplate
 
-    backend = session.backends["dragon"]
+    backend = session_v3.backends["dragon"]
     captured = []
 
     def capture(pt, **kw):
@@ -597,10 +564,90 @@ async def test_process_template_combined_spec_policy_cwd_args(session, backend_n
     assert isinstance(pt, ProcessTemplate)
     assert pt.policy is policy
     assert pt.cwd == "/tmp"
-    # For Python functions Dragon serializes (target, args, kwargs) into pt.argdata via cloudpickle;
-    # pt.args holds the subprocess launch command, not the user's args.
-    import cloudpickle
-
+    # Dragon serialises (target, args, kwargs) into pt.argdata via cloudpickle.
     _, stored_args, stored_kwargs = cloudpickle.loads(pt.argdata)
     assert list(stored_args) == [42]
     assert stored_kwargs == {"flag": True}
+
+
+# ============================================================================
+# V3 unit tests — constructor and internal methods (no Dragon cluster required)
+# ============================================================================
+
+
+def test_v3_constructor_accepts_new_params_and_forwards_to_batch():
+    """num_nodes, pool_nodes, and disable_telemetry are accepted and forwarded to Batch."""
+    from rhapsody.backends.execution.dragon import DragonExecutionBackendV3
+
+    mock_batch = MagicMock()
+    mock_batch.num_workers = 8
+    mock_batch.num_managers = 1
+
+    with patch("rhapsody.backends.execution.dragon.Batch", return_value=mock_batch) as MockBatch:
+        backend = DragonExecutionBackendV3(num_nodes=4, pool_nodes=2, disable_telemetry=True)
+
+    MockBatch.assert_called_once_with(num_nodes=4, pool_nodes=2, disable_telem=True)
+    assert backend.batch is mock_batch
+
+
+def test_v3_constructor_rejects_removed_params():
+    """num_workers, disable_background_batching, and disable_batch_submission no longer exist."""
+    from rhapsody.backends.execution.dragon import DragonExecutionBackendV3
+
+    mock_batch = MagicMock()
+    mock_batch.num_workers = 8
+    mock_batch.num_managers = 1
+
+    with patch("rhapsody.backends.execution.dragon.Batch", return_value=mock_batch):
+        with pytest.raises(TypeError):
+            DragonExecutionBackendV3(num_workers=4)
+        with pytest.raises(TypeError):
+            DragonExecutionBackendV3(disable_background_batching=True)
+        with pytest.raises(TypeError):
+            DragonExecutionBackendV3(disable_batch_submission=True)
+
+
+def test_v3_deliver_result_stores_value_and_fires_done(backend_v3):
+    """_deliver_result stores return_value on the task dict and fires the DONE callback."""
+    uid = "task.unit-done"
+    task_desc = {"uid": uid}
+    backend_v3._task_registry[uid] = {"uid": uid, "description": task_desc}
+
+    backend_v3._deliver_result(uid, result=42)
+
+    assert task_desc["return_value"] == 42
+    backend_v3._callback_func.assert_called_once_with(task_desc, "DONE")
+
+
+def test_v3_deliver_failure_stores_exc_and_fires_failed(backend_v3):
+    """_deliver_failure stores the exception and stderr string, fires the FAILED callback."""
+    uid = "task.unit-failed"
+    task_desc = {"uid": uid}
+    backend_v3._task_registry[uid] = {"uid": uid, "description": task_desc}
+    exc = RuntimeError("something went wrong")
+
+    backend_v3._deliver_failure(uid, exc)
+
+    assert task_desc["exception"] is exc
+    assert "something went wrong" in task_desc["stderr"]
+    backend_v3._callback_func.assert_called_once_with(task_desc, "FAILED")
+
+
+def test_v3_cancelled_task_skips_both_callbacks(backend_v3):
+    """_deliver_result and _deliver_failure are no-ops for UIDs in _cancelled_tasks."""
+    uid = "task.unit-cancelled"
+    task_desc = {"uid": uid}
+    backend_v3._task_registry[uid] = {"uid": uid, "description": task_desc}
+    backend_v3._cancelled_tasks.append(uid)
+
+    backend_v3._deliver_result(uid, result=99)
+    backend_v3._deliver_failure(uid, RuntimeError("ignored"))
+
+    backend_v3._callback_func.assert_not_called()
+    assert "return_value" not in task_desc
+
+
+def test_v3_fence_delegates_to_batch(backend_v3):
+    """backend.fence() calls batch.fence() exactly once."""
+    backend_v3.fence()
+    backend_v3.batch.fence.assert_called_once()


### PR DESCRIPTION
## Refactor Dragon batch integration and task monitoring flow

- Added fallback stub import for Batch and TaskNotReadyError
  - from dragon.workflows.batch import Batch, TaskNotReadyError

- Simplified constructor (__init__)
  - Removed: num_workers, disable_background_batching, disable_batch_submission
  - Added: num_nodes, pool_nodes
  - Updated Batch(...) initialization accordingly

- Reworked _monitor_loop
  - Replaced compiled_tasks.wait(timeout=0.01) with direct access to `result_ddict`
  - Updated tuple structure from (compiled_task, list[uid]) → (batch_task, uid)

- Removed _process_batch_results
  - Introduced _deliver_result(uid, result)
  - Introduced _deliver_failure(uid, exc)
  - Results now retrieved directly via task.get()

- Simplified submit_tasks
  - Removed compile + start logic
  - Now directly registers batch_task.uid → (batch_task, uid) in _monitored_batches

- Updated create_ddict
  - Replaced self.batch.ddict(...) with direct DDict(...) construction

- Updated create() classmethod
  - Removed obsolete parameters
  - Aligned with new constructor signature



## Performance analysis:

### `Dragon.batch`  +  `RHAPSODY`:

| Run # | tasks                | Time (seconds) |
| ----: | --------------------- | -------------: |
|     1 | 10k|        10.5022 |
|     2 | 10k |        12.1721 |
|     3 | 10k |         9.9246 |
|     4 | 10k |        11.1760 |

### `Dragon.batch` only:

| Run # | tasks                | Time (seconds) |
| ----: | --------------------- | -------------: |
|     1 | 10k   |         9.8233 |
|     2 | 10k    |         10.921 |
|     3 | 10k   |         9.9936 |
|     4 | 10k    |         10.0773 |
