### PR TITLE
fix(dragon V3): guard results_ddict subscript with __contains__ to unwedge multi-node monitor loop

### DIFF
--- a/src/rhapsody/backends/execution/dragon.py
+++ b/src/rhapsody/backends/execution/dragon.py
@@ -3195,7 +3195,11 @@ class DragonExecutionBackendV3(BaseBackend):
                 for tuid in batch_tuids:
                     if tuid not in self._monitored_batches:
                         continue
-                    # Single DDict read: KeyError means not ready yet (avoids redundant __contains__)
+                    # ``__contains__`` first: a bare subscript on Dragon's
+                    # distributed DDict blocks on remote-peer keys at
+                    # multi-node scale instead of raising KeyError.
+                    if tuid not in self.batch.results_ddict:
+                        continue
                     try:
                         result, tb, raised, stdout, stderr = self.batch.results_ddict[tuid]
                     except KeyError:


### PR DESCRIPTION
## Summary

The V3 monitor loop hangs on multi-node Dragon allocations because the bare
``self.batch.results_ddict[tuid]`` subscript blocks indefinitely on remote-peer
keys instead of raising ``KeyError``.  Symptom in the field: tasks complete on
compute nodes (output files appear), ``RUNNING`` callbacks fire, but no
``DONE``/``FAILED`` callback ever reaches downstream consumers — the asyncio
event loop is starved of completions and the thread refuses to exit on
shutdown (``Batch monitor thread did not stop within timeout``).

## Root cause

The ``__getitem__`` semantics of Dragon's distributed ``DDict`` differ between
single-node and multi-node setups: on one node the lookup is local and a
missing key raises ``KeyError`` immediately; on N>1 nodes, the lookup is a
network call to the responsible peer and waits for the entry to appear rather
than raising.  The monitor loop's optimisation —

```python
# Single DDict read: KeyError means not ready yet (avoids redundant __contains__)
try:
    result, tb, raised, stdout, stderr = self.batch.results_ddict[tuid]
except KeyError:
    continue
```

— relies on the single-node behaviour and silently wedges in the multi-node
case.

Bisect: introduced in **1646aa1** (*"Revert from task.get to result_ddict[task.uid] for better control on how to obtain results"*, 2026-04-03), which dropped the prior ``task.get(timeout=…)`` polling that respected a timeout.

## Fix

Membership-check first; the bare subscript still has its ``KeyError`` fallback
to cover the contains/read race window:

```python
if tuid not in self.batch.results_ddict:
    continue
try:
    result, tb, raised, stdout, stderr = self.batch.results_ddict[tuid]
except KeyError:
    continue
```

Verified end-to-end on a 2-node Dragon allocation on Perlmutter: terminal
``DONE`` callbacks now flow to the StateManager and out via the radical.edge
notification path within milliseconds of task completion.

## Notes / open questions for the Dragon side

A proper fix probably belongs in Dragon: ``DDict.__getitem__`` and/or
``__contains__`` should not silently block on a missing remote key, or there
should be a documented non-blocking variant (``get(default=…)``, ``peek(...)``).
This patch is a workaround that gets the multi-node case unstuck today.

## Test plan

- [x] Manual: 2-node Dragon allocation + 2 PsiJ-submitted tasks → terminal
      callbacks observed in the radical.edge log (previously absent).
- [ ] Add a regression test that mocks ``results_ddict.__getitem__`` to block
      on a missing key, asserts the monitor loop still progresses.