### PR TITLE
Optimize Telemtry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,184 @@
 
 ### Added
 
+- **`SpanBuffer`** — new public, thread-safe span collector that replaces
+  `InMemorySpanExporter` as RHAPSODY's internal span store. Uses `list.extend()`
+  for O(1) appends (vs. the exporter's O(n²) `tuple +=` per flush). `shutdown()`
+  is a no-op so spans remain accessible after `tracer_provider.shutdown()`.
+  `get_finished_spans()`, `clear()`, and `force_flush()` match the
+  `InMemorySpanExporter` API.
+
+- **Provider-agnostic OTel injection** — `TelemetryManager.__init__()` and
+  `Session.start_telemetry()` accept three new optional parameters:
+  - `span_processors: list | None` — OTel `SpanProcessor` instances
+    (e.g. `BatchSpanProcessor(OTLPSpanExporter())`) added to RHAPSODY's private
+    `TracerProvider` alongside the internal `SpanBuffer`. Callers own exporter
+    construction; RHAPSODY never imports specific exporter classes.
+  - `metric_readers: list | None` — OTel `MetricReader` instances
+    (e.g. `PeriodicExportingMetricReader(OTLPMetricExporter())`) added to
+    RHAPSODY's private `MeterProvider` alongside `InMemoryMetricReader`.
+  - `resource: Resource | None` — optional OTel `Resource` override.
+    `None` (default) calls `Resource.create()` which reads `OTEL_SERVICE_NAME`
+    and `OTEL_RESOURCE_ATTRIBUTES` from the environment automatically.
+
+- **`TelemetryManager.annotate_current_span(event)`** — records a `BaseEvent`
+  as an OTel span event (with serialized attributes) on the currently active
+  span. No-op when no valid span is active or telemetry is stopped.
+
+- **`TelemetryManager.register_span_enricher(func)`** — registers a callback
+  invoked at `TaskCreated` time that returns extra `dict` attributes to stamp
+  onto the task's OTel span. Multiple enrichers are applied in registration
+  order. Used by orchestration layers (e.g. AsyncFlow) to inject workflow-level
+  grouping keys.
+
+- **`TelemetryManager.export_as_otlp(path=None)`** — serializes all finished
+  spans to a standards-compliant OTLP JSON payload (the POST `/v1/traces` wire
+  format: 32/16-char hex IDs, nanosecond timestamps as strings, typed KV
+  attributes). Returns the JSON string and optionally writes to `path`.
+
+- **`TelemetryManager._task_contexts`** — internal dict that captures the OTel
+  context (`context.get_current()`) at `TaskCreated` emit time and restores it
+  via `attach/detach` in `_process_event()`. This is the standard in-process OTel
+  propagation pattern across asyncio task boundaries.
+
+- **`TelemetryManager._session_ctx_token`** — stores the attach token for the
+  session span context, detached cleanly in `stop()`.
+
+### Performance
+
+- **Batch-drain dispatch loop** — replaced the per-event
+  `asyncio.wait_for(queue.get(), timeout=0.05)` pattern in `_dispatch_loop`
+  with a batch-drain approach that reduces asyncio event-loop interactions from
+  O(N) to O(N/500) under burst load.
+
+  Key changes:
+  - Fast path: drain up to 500 events per iteration with `queue.get_nowait()`
+    (plain `deque.popleft()` — zero asyncio scheduling overhead, no timer handle,
+    no `Task` allocation per event). Fall back to a blocking `await queue.get()`
+    only when the queue is empty.
+  - `asyncio.sleep(0)` yielded once per *full* batch, not once per event.
+    Partial batches block naturally on the next `await queue.get()`.
+  - `_flush_batch()` — new helper that processes OTel instruments, writes the
+    JSONL checkpoint, and dispatches to subscribers for an entire batch at once.
+    Subscriber dispatch is guarded by `if self._subscribers` to skip the inner
+    loop when no subscribers are registered.
+  - `_write_batch()` — new helper that serializes a batch of events and issues a
+    **single `file.write()` call** per batch. Uses
+    `dataclasses.fields() + getattr` instead of `dataclasses.asdict()`: avoids
+    the deep-recursive copy, and correctly captures `init=False` class-level
+    fields (e.g. `event_type`) that `vars()` / `__dict__` miss on frozen
+    dataclass subclasses.
+  - Checkpoint file opened with `buffering=131072` (128 KB block buffer) instead
+    of `buffering=1` (line-buffered). The previous setting issued one `write()`
+    syscall per event — up to 80 000 syscalls for a 40 K-task session.
+  - **Sentinel-based shutdown** — `stop()` sets `_running=False`, awaits
+    `queue.join()` with a 5 s timeout to guarantee full drain, then pushes
+    `_STOP_SENTINEL` to unblock the dispatch loop cleanly. `emit()` is now a
+    no-op after `stop()` to prevent late emissions racing with the sentinel.
+
+  Measured at 40 000 tasks (`DragonExecutionBackend`):
+
+  | | Telemetry overhead |
+  |---|---|
+  | Before (per-event `wait_for`) | +7 s (3.66× slower than no-telemetry) |
+  | After (batch-drain) | +2 s (1.73× slower than no-telemetry) |
+
+  **71% reduction in telemetry overhead** at 40 K tasks.
+
+### Fixed
+
+- **`TaskCreated` as task span head** — task spans were previously opened at
+  `TaskSubmitted`, leaving `TaskCreated` (the earliest lifecycle event) with
+  only a `trace_id` and no `span_id` in the JSONL. The span is now opened at
+  `TaskCreated` so all lifecycle events carry both `trace_id` and `span_id`,
+  making the JSONL 100% OTel-aligned from the first event.
+
+- **Same-batch span ordering hazard** — when `TaskCreated` and
+  `TaskCompleted` / `TaskFailed` land in the same 500-event batch,
+  `_process_event` closes the span before `_span_ids_for_event` can look it up
+  for intermediate events in the batch. Fixed by:
+  - `_completed_span_ctx` dict: stores the `SpanContext` snapshot when a span
+    is ended so intermediate events in the same batch can still retrieve it
+    via `.get()` (not `.pop()`).
+  - Terminal events (Completed/Failed/Canceled) `.pop()` the entry, ensuring
+    no unbounded growth.
+  - Same fix applied to the session span: `_completed_session_ctx` snapshot is
+    taken at `SessionEnded` so JSONL serialization for same-batch session events
+    still finds a valid context.
+
+- **`ResourceUpdate` JSONL correlation** — `ResourceUpdate` events now carry
+  the session span's `trace_id` and `span_id` (previously `(None, None)`),
+  making node and GPU metrics queryable within the session trace in Jaeger /
+  Tempo.
+
+- **`TaskSubmitted` / `TaskQueued` fallback** — if `TaskCreated` was never
+  seen (incomplete lifecycle, e.g. task registered before telemetry started),
+  `TaskSubmitted` opens the task span instead, preserving best-effort
+  correlation.
+
+- **External trace/span injection** — components outside RHAPSODY (e.g. an
+  orchestration layer or application code) can now emit events that carry an
+  explicit `trace_id` / `span_id` and have them written to the JSONL with the
+  correct OTel correlation IDs, enabling cross-component trace stitching.
+
+- **Memory leak in `ConcurrentExecutionBackend._run_executable`** — file
+  handles (`stdout_f`, `stderr_f`) opened for `capture_stdio=True` tasks were
+  not closed on exception paths (subprocess launch failure, timeout, etc.).
+  Refactored to initialize both handles and `exit_code` before the `try` block
+  and close them in `finally`, eliminating the leak.
+
+- **OTel span parent hierarchy** — task spans previously had no parent span and
+  scattered across multiple unrelated traces. Root cause: `_dispatch_loop` runs
+  in a separate asyncio `Task` and does not inherit the calling coroutine's OTel
+  context. Fix: capture `context.get_current()` at `TaskCreated` emit time,
+  store in `_task_contexts`, restore via `attach/detach` in `_process_event()`.
+  All task spans now correctly nest under the session root span in the trace
+  hierarchy.
+
+- **`span_scope()` session span fallback** — when called from a context with no
+  valid active span (e.g. inside a block body spawned before `start_telemetry()`),
+  `span_scope()` now explicitly uses `self._session_span` as the parent context
+  instead of creating a root span. Replaces custom `_null_context()` with stdlib
+  `nullcontext`.
+
+
+### Changed
+
+- **`TelemetryManager.export_as_otlp()`** — renamed from
+  `export_traces_otlp_json()` for consistency with the OTel ecosystem naming
+  convention.
+
+- **`TelemetryManager.start()` OTel provider setup** — always uses
+  `Resource.create({"service.name": "rhapsody", "session_id": ...})` as the
+  default resource (reads `OTEL_SERVICE_NAME` from env automatically as
+  fallback). Caller-supplied `span_processors` are added via
+  `tracer_provider.add_span_processor()` after the internal `SpanBuffer` processor.
+  Caller-supplied `metric_readers` are appended to the `MeterProvider` reader
+  list alongside the internal `InMemoryMetricReader`.
+
+### Docs
+
+- **`docs/telemetry/integrations.md`**:
+  - Fixed "Connecting an OTLP exporter" section: removed the broken
+    `set_tracer_provider()` pattern (RHAPSODY creates private providers and
+    ignores globals) and replaced with the correct `span_processors=` injection.
+    Added tip block showing env-var configuration for Honeycomb/Grafana Cloud.
+  - Fixed "Grafana + Prometheus Step 3": removed `set_meter_provider()` pattern;
+    replaced with `metric_readers=[PrometheusMetricReader()]`.
+  - Updated "What RHAPSODY produces" table: `InMemorySpanExporter` → `SpanBuffer`.
+
+- **`docs/telemetry/quickstart.md`**: added three missing rows to the
+  `start_telemetry` parameters table (`span_processors`, `metric_readers`,
+  `resource`).
+
+- **`docs/telemetry/reference.md`**: added "Span annotation and enrichment API"
+  section documenting `span_scope()`, `annotate_current_span()`,
+  `register_span_enricher()`, and `export_as_otlp()`.
+
+- **`docs/telemetry/index.md`**: updated "OpenTelemetry compatibility" paragraph
+  to accurately describe the private-provider model and direct users to the
+  `span_processors`/`metric_readers` injection API.
+
 - `ComputeTask`: new `capture_stdio: bool = False` parameter. When `True`, stdout and stderr from executable tasks are redirected directly to files (`{work_dir}/{session_uid}/{task_uid}.stdout` / `.stderr`) with zero in-memory buffering. `task.stdout` and `task.stderr` then hold file paths instead of decoded strings. Function tasks are unaffected regardless of the flag value.
 - `ConcurrentExecutionBackend`: honours `capture_stdio` by passing open file handles to `asyncio.create_subprocess_exec` / `asyncio.create_subprocess_shell`; the kernel writes directly, no Python-level buffering.
 - `DaskExecutionBackend`: honours `capture_stdio` in the module-level `_run_executable` function; file handles are passed to `subprocess.run` inside the worker process.

--- a/docs/telemetry/index.md
+++ b/docs/telemetry/index.md
@@ -85,7 +85,7 @@ This means:
 
 ## OpenTelemetry compatibility
 
-All RHAPSODY telemetry data is produced through the **OpenTelemetry Python SDK**. The in-memory providers can be swapped for any OTLP-compatible exporter (Jaeger, Tempo, Prometheus, Dynatrace) by pointing the SDK at your collector — no RHAPSODY code changes required.
+All RHAPSODY telemetry data is produced through the **OpenTelemetry Python SDK**. RHAPSODY creates its own private `TracerProvider` and `MeterProvider` with in-memory storage. To forward data to any OTel-compatible backend (Jaeger, Tempo, Prometheus, Dynatrace, Honeycomb), pass pre-built `SpanProcessor` and/or `MetricReader` instances to `start_telemetry()` — no other RHAPSODY code changes required. See [Integrations & Extensions](integrations.md#connecting-an-otlp-exporter-jaeger-tempo-dynatrace) for examples.
 
 The JSONL checkpoint file is a portable, OTel-aligned export that can be replayed, plotted, or ingested into any time-series tool.
 

--- a/docs/telemetry/integrations.md
+++ b/docs/telemetry/integrations.md
@@ -12,35 +12,46 @@ RHAPSODY uses `opentelemetry-sdk` internally with **in-memory providers** (no ex
 
 | Signal | OTel type | Provider |
 |---|---|---|
-| Task / session traces | Spans (`ReadableSpan`) | `TracerProvider` → `InMemorySpanExporter` |
+| Task / session traces | Spans (`ReadableSpan`) | `TracerProvider` → `SpanBuffer` (in-memory) |
 | Counters, gauges, histograms | Metrics (`MetricsData`) | `MeterProvider` → `InMemoryMetricReader` |
 | Raw events | JSONL file lines | RHAPSODY checkpoint writer |
 
 ### Connecting an OTLP exporter (Jaeger, Tempo, Dynatrace…)
 
-Because RHAPSODY uses the standard OTel SDK, you can add any exporter **before** calling `start_telemetry()`:
+RHAPSODY creates its own private `TracerProvider` and `MeterProvider` at `start_telemetry()` time. To forward data to an external backend, pass your pre-built `SpanProcessor` and/or `MetricReader` instances — the standard OTel extension points. RHAPSODY wires them into its providers alongside the internal `SpanBuffer` / `InMemoryMetricReader`:
 
 ```python
-from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 
-# Build a custom TracerProvider with an OTLP exporter
-provider = TracerProvider()
-provider.add_span_processor(
-    BatchSpanProcessor(OTLPSpanExporter(endpoint="http://localhost:4317"))
+telemetry = await session.start_telemetry(
+    checkpoint_path="./tel/",
+    span_processors=[BatchSpanProcessor(OTLPSpanExporter(endpoint="http://localhost:4317"))],
 )
-
-# Inject it before start_telemetry()
-from opentelemetry import trace
-trace.set_tracer_provider(provider)
-
-telemetry = await session.start_telemetry(checkpoint_path="./tel/")
 # … run session …
 await session.close()   # stops telemetry automatically
 ```
 
-All task spans will now appear in Jaeger / Grafana Tempo alongside the in-memory copy.
+All task spans now flow to both Jaeger / Grafana Tempo **and** the in-memory `SpanBuffer` (powering `read_traces()` / `task_spans()`). RHAPSODY never imports specific exporter classes — you own exporter construction and configuration entirely.
+
+!!! tip "Environment-based configuration"
+    OTel exporters read `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, and
+    `OTEL_SERVICE_NAME` from the environment automatically. Pair this with `Resource.create()`
+    via the `resource` parameter:
+
+    ```python
+    import os
+    os.environ["OTEL_SERVICE_NAME"] = "my-app"
+    os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "https://api.honeycomb.io"
+    os.environ["OTEL_EXPORTER_OTLP_HEADERS"] = "x-honeycomb-team=YOUR_API_KEY"
+
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+
+    telemetry = await session.start_telemetry(
+        span_processors=[BatchSpanProcessor(OTLPSpanExporter())],
+    )
+    ```
 
 ---
 
@@ -82,21 +93,16 @@ pip install opentelemetry-exporter-prometheus
 ### Step 3 — wire RHAPSODY metrics to the exporter
 
 ```python
-from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.exporter.prometheus import PrometheusMetricReader
 from prometheus_client import start_http_server
 
 # Serve Prometheus metrics on port 9464
 start_http_server(port=9464)
-reader = PrometheusMetricReader()
-provider = MeterProvider(metric_readers=[reader])
-
-from opentelemetry import metrics
-metrics.set_meter_provider(provider)
 
 telemetry = await session.start_telemetry(
     resource_poll_interval=5.0,
     checkpoint_path="./tel/",
+    metric_readers=[PrometheusMetricReader()],
 )
 ```
 

--- a/docs/telemetry/quickstart.md
+++ b/docs/telemetry/quickstart.md
@@ -54,9 +54,9 @@ asyncio.run(main())
     "duration_seconds": 3.42,
     "tasks": {
         "submitted": 20,
-        "started":   20,
         "completed": 20,
         "failed":     0,
+        "canceled":   0,
         "running":    0,
     },
     "duration": {
@@ -67,6 +67,8 @@ asyncio.run(main())
     },
     "resources": {
         "concurrent/myhost": {
+            "backend":           "concurrent",
+            "node_id":           "myhost",
             "cpu_percent":       41.2,
             "memory_percent":    28.7,
             "gpu_percent":       None,

--- a/docs/telemetry/quickstart.md
+++ b/docs/telemetry/quickstart.md
@@ -209,6 +209,9 @@ This produces a multi-panel PNG (shown in [Integrations — Real Run Visualizati
 | `resource_poll_interval` | `float` | `5.0` | Seconds between resource metric polls |
 | `checkpoint_interval` | `float \| None` | `None` | Seconds between periodic metric+span flushes. `None` = flush only at session end |
 | `checkpoint_path` | `str \| None` | `None` | Directory for the JSONL file. `None` = no file output |
+| `span_processors` | `list \| None` | `None` | OTel `SpanProcessor` instances (e.g. `BatchSpanProcessor(OTLPSpanExporter())`) added alongside RHAPSODY's internal `SpanBuffer`. Callers own exporter construction. |
+| `metric_readers` | `list \| None` | `None` | OTel `MetricReader` instances (e.g. `PeriodicExportingMetricReader(OTLPMetricExporter())`) added alongside RHAPSODY's internal `InMemoryMetricReader`. |
+| `resource` | `Resource \| None` | `None` | OTel `Resource` override. `None` = `Resource.create()` reads `OTEL_SERVICE_NAME` / `OTEL_RESOURCE_ATTRIBUTES` from the environment automatically. |
 
 To access the manager after the initial call use `session.get_telemetry()`.
 

--- a/docs/telemetry/reference.md
+++ b/docs/telemetry/reference.md
@@ -95,7 +95,7 @@ attributes = {
 ```
 
 !!! note "OTel correlation"
-    At submission time no task span exists yet.  The JSONL `trace_id` is the session trace ID (so the event is queryable within the right trace), but `span_id` is `null`.
+    The task span is already open at this point (opened at `TaskCreated`). The JSONL `trace_id` and `span_id` are those of the task span, making this event queryable as a child of the session span in any OTel-compatible tool.
 
 ---
 
@@ -107,7 +107,7 @@ Emitted just before the task is handed to the backend's internal queue. Marks th
 attributes = { "executable": str, "task_type": str }
 ```
 
-Same OTel correlation as `TaskSubmitted` — trace-linked but no task span yet.
+Same OTel correlation as `TaskSubmitted` — the task span is already open; `trace_id` and `span_id` are both set.
 
 ---
 
@@ -120,7 +120,7 @@ attributes = { "executable": str, "task_type": str }
 ```
 
 !!! note "OTel correlation"
-    Opening this event **opens the task OTel span** (named `"task"`) as a child of the session span. The JSONL `trace_id` and `span_id` are those of the freshly opened task span.
+    The task OTel span (named `"task"`) was opened at `TaskCreated`. This event is recorded as an annotation on that already-open span. The JSONL `trace_id` and `span_id` are those of the task span.
 
 ---
 
@@ -424,10 +424,10 @@ task span
 │     task_type  = "compute"
 │     status     = "completed" | "failed"
 │     error_type = "RuntimeError"   (failed tasks only)
-└── duration: TaskStarted.event_time → TaskCompleted.event_time
+└── duration: TaskCreated (span open) → TaskCompleted/Failed/Canceled (span close)
 ```
 
-The span duration is derived from the backend's own task history timestamps — not from event queue latency — so it reflects true execution time.
+The span covers the full task lifecycle from registration to terminal state. To get pure execution time, use the `task_duration_seconds` OTel histogram metric, which is recorded from `TaskStarted` → terminal state.
 
 ### Trace–span correlation in the JSONL file
 
@@ -436,7 +436,7 @@ Every line in the checkpoint file carries two extra keys added at serialization 
 | JSONL key | Source |
 |---|---|
 | `trace_id` | Hex string of the OTel trace ID |
-| `span_id` | Hex string of the correlated span ID (`null` for TaskSubmitted/TaskQueued) |
+| `span_id` | Hex string of the correlated span ID — always non-null for all task lifecycle and session events |
 | `name` | Alias for `event_type` (OTel-compatible) |
 
 This makes the JSONL file directly importable into any OTel-aware tool as a timeline.

--- a/docs/telemetry/reference.md
+++ b/docs/telemetry/reference.md
@@ -443,6 +443,75 @@ This makes the JSONL file directly importable into any OTel-aware tool as a time
 
 ---
 
+## Span annotation and enrichment API
+
+These methods let application code interact with the active OTel span without importing OTel directly.
+
+### `span_scope(name, attributes=None)`
+
+Context manager that opens a child span under the currently active span (or under the session span when called outside a task context).
+
+```python
+with telemetry.span_scope("preprocessing", {"dataset": "train_2024"}):
+    # Any spans opened here will be children of "preprocessing"
+    process_data()
+```
+
+Useful for grouping a sequence of operations into a named sub-trace. If telemetry is not started, `span_scope()` is a no-op.
+
+---
+
+### `annotate_current_span(event)`
+
+Records a `BaseEvent` as an **annotation** (OTel span event) on the currently active span. Does nothing if there is no active span.
+
+```python
+def on_event(event):
+    if event.event_type == "TaskCompleted":
+        telemetry.annotate_current_span(event)
+
+telemetry.subscribe(on_event)
+```
+
+Attributes are serialized to strings. Useful for linking RHAPSODY lifecycle events to custom spans opened with `span_scope()`.
+
+---
+
+### `register_span_enricher(func)`
+
+Registers a callback that is called for every `TaskCreated` event and returns extra attributes to add to that task's OTel span.
+
+```python
+telemetry.register_span_enricher(
+    lambda event: {"my.workflow_id": event.attributes.get("my.workflow_id", "")}
+)
+```
+
+`func` receives a `BaseEvent` and must return a `dict[str, str | int | float | bool]`. Multiple enrichers are applied in registration order. Enrichers are the correct place to stamp custom grouping keys (workflow IDs, pipeline names, etc.) onto task spans without modifying RHAPSODY source.
+
+---
+
+### `export_as_otlp(path=None)`
+
+Serializes all finished spans to a standards-compliant OTLP JSON payload (the `POST /v1/traces` wire format). Call after `stop()` when all spans are finalized.
+
+```python
+await session.close()
+
+# Write to file
+telemetry.export_as_otlp("./traces.json")
+
+# Or get the JSON string directly
+payload = telemetry.export_as_otlp()
+```
+
+The returned string is valid OTLP JSON and can be:
+- Uploaded to any visualizer that accepts OTLP format (Jaeger, Grafana Tempo, Zipkin with conversion)
+- POSTed directly to an OTLP HTTP endpoint
+- Stored for offline analysis
+
+---
+
 ## JSONL checkpoint format
 
 Each line in the `.telemetry.jsonl` file is a JSON object with a `"section"` discriminator:

--- a/src/rhapsody/api/session.py
+++ b/src/rhapsody/api/session.py
@@ -296,6 +296,9 @@ class Session:
         resource_poll_interval: float = 5.0,
         checkpoint_interval: float | None = None,
         checkpoint_path: str | None = None,
+        span_processors: list | None = None,
+        metric_readers: list | None = None,
+        resource: object | None = None,
     ) -> TelemetryManager:
         """Enable and start telemetry collection for this session in one call.
 
@@ -314,6 +317,22 @@ class Session:
                                     None = no periodic flush (file still written at stop).
             checkpoint_path:        Directory for the JSONL checkpoint file.
                                     None = no file output.
+            span_processors:        Optional list of
+                                    ``opentelemetry.sdk.trace.SpanProcessor`` instances
+                                    (e.g. ``BatchSpanProcessor(OTLPSpanExporter())``)
+                                    added to RHAPSODY's TracerProvider alongside the
+                                    internal SpanBuffer. Callers own exporter construction
+                                    and configuration.
+            metric_readers:         Optional list of
+                                    ``opentelemetry.sdk.metrics.export.MetricReader``
+                                    instances (e.g.
+                                    ``PeriodicExportingMetricReader(OTLPMetricExporter())``)
+                                    added to RHAPSODY's MeterProvider alongside the
+                                    internal InMemoryMetricReader.
+            resource:               Optional ``opentelemetry.sdk.resources.Resource``.
+                                    When None (default), ``Resource.create()`` is called
+                                    automatically and reads ``OTEL_SERVICE_NAME`` /
+                                    ``OTEL_RESOURCE_ATTRIBUTES`` from the environment.
 
         Returns:
             The active :class:`~rhapsody.telemetry.manager.TelemetryManager`.
@@ -328,6 +347,9 @@ class Session:
             session_id=self.uid,
             checkpoint_interval=checkpoint_interval,
             checkpoint_path=checkpoint_path,
+            span_processors=span_processors,
+            metric_readers=metric_readers,
+            resource=resource,
         )
         self._state_manager._telemetry_observer = self._telemetry._on_task_state_change
 

--- a/src/rhapsody/telemetry/manager.py
+++ b/src/rhapsody/telemetry/manager.py
@@ -15,6 +15,7 @@ import dataclasses
 import json
 import logging
 import time
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Any
@@ -39,6 +40,41 @@ logger = logging.getLogger(__name__)
 
 # Pushed onto the queue by stop() after queue.join() to unblock the dispatch loop cleanly.
 _STOP_SENTINEL = object()
+
+
+class SpanBuffer:
+    """O(1)-append in-process span store.
+
+    InMemorySpanExporter (an OTel test utility) does `_finished_spans += tuple(spans)` on every
+    export call — O(n) per call, O(n²) total for n spans. For 40K spans that costs ~4 seconds inside
+    the dispatch loop. list.extend() keeps append at O(1) amortized.
+
+    Implements the SpanExporter interface so it can be passed to any SpanProcessor.
+    """
+
+    def __init__(self) -> None:
+        import threading
+
+        self._spans: list = []
+        self._lock = threading.Lock()
+
+    def export(self, spans) -> None:
+        with self._lock:
+            self._spans.extend(spans)
+
+    def get_finished_spans(self) -> tuple:
+        with self._lock:
+            return tuple(self._spans)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._spans.clear()
+
+    def shutdown(self) -> None:
+        pass  # keep spans accessible via get_finished_spans() after tracer_provider.shutdown()
+
+    def force_flush(self, timeout_millis: int = 30_000) -> bool:
+        return True
 
 
 class TelemetryManager:
@@ -124,6 +160,19 @@ class TelemetryManager:
         # Last-seen resource values for UpDownCounter delta tracking
         self._last: dict[str, dict[str, float]] = {"cpu": {}, "mem": {}, "gpu": {}}
 
+        # Registered by higher-layer runtimes to inject custom OTel span attributes.
+        # Each callable receives the event and returns a dict of extra attributes.
+        self._span_attribute_extractors: list[Callable[[BaseEvent], dict]] = []
+
+        # OTel context snapshot captured at emit() time for each TaskCreated event.
+        # Keyed by task_id. Consumed (popped) in _process_event() to restore the
+        # correct parent span context in the dispatch loop.
+        self._task_contexts: dict[str, Any] = {}
+
+        # Token returned by context.attach() when the session span is activated in start().
+        # Stored so it can be properly detached in stop().
+        self._session_ctx_token: Any = None
+
     # ------------------------------------------------------------------
     # Public properties
     # ------------------------------------------------------------------
@@ -143,10 +192,9 @@ class TelemetryManager:
         from opentelemetry.sdk.metrics.export import InMemoryMetricReader
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.sdk.trace.export import SimpleSpanProcessor
-        from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
         self._metric_reader = InMemoryMetricReader()
-        self._span_exporter = InMemorySpanExporter()
+        self._span_exporter = SpanBuffer()
         self._meter_provider = MeterProvider(metric_readers=[self._metric_reader])
         self._tracer_provider = TracerProvider()
         self._tracer_provider.add_span_processor(SimpleSpanProcessor(self._span_exporter))
@@ -160,6 +208,20 @@ class TelemetryManager:
             self._open_checkpoint_file()
 
         self._session_start_time = time.time()
+
+        # Create the session span synchronously so it is available before any
+        # workflow_scope() / span_scope() call — _dispatch_loop runs in a separate
+        # asyncio task and would otherwise process SessionStarted too late.
+        self._session_span = self._tracer.start_span(
+            "session", attributes={"session_id": self._session_id, "backend": "rhapsody"}
+        )
+        from opentelemetry import context as otel_context
+        from opentelemetry import trace as trace_mod
+
+        self._session_ctx_token = otel_context.attach(
+            trace_mod.set_span_in_context(self._session_span)
+        )
+
         self._running = True
         self._dispatch_task = asyncio.create_task(self._dispatch_loop(), name="telemetry-dispatch")
 
@@ -227,6 +289,12 @@ class TelemetryManager:
             self._checkpoint_file.close()
             self._checkpoint_file = None
 
+        from opentelemetry import context as otel_context
+
+        if self._session_ctx_token is not None:
+            otel_context.detach(self._session_ctx_token)
+            self._session_ctx_token = None
+
         if self._meter_provider:
             self._meter_provider.shutdown()
         if self._tracer_provider:
@@ -237,13 +305,19 @@ class TelemetryManager:
     # ------------------------------------------------------------------
 
     def emit(self, event: BaseEvent) -> None:
-        """Enqueue an event for processing.
+        """Enqueue an event for async processing (JSONL, metrics, spans).
 
-        Non-blocking, O(1), safe to call from any context. No-op once stop() has been called.
+        Non-blocking, O(1) for all event types. For TaskCreated events, captures the caller's OTel
+        context so _process_event() can restore it in the dispatch loop and create the task span
+        with the correct structural parent.
         """
         if not self._running:
             return
         self._queue.put_nowait(event)
+        if self._tracer is not None and event.event_type == "TaskCreated":
+            from opentelemetry import context as _ctx
+
+            self._task_contexts[event.task_id] = _ctx.get_current()
 
     def subscribe(self, callback: Callable[[BaseEvent], Any]) -> None:
         """Register a callback to receive every event.
@@ -252,6 +326,63 @@ class TelemetryManager:
         callbacks never crash the dispatch loop.
         """
         self._subscribers.append(callback)
+
+    def annotate_current_span(self, event: BaseEvent) -> None:
+        """Add this event as a timestamped annotation on the currently active OTel span.
+
+        Must be called from a context where a span is active (e.g. inside span_scope()). No-op if no
+        valid span is active or telemetry has not been started.
+        """
+        if self._tracer is None:
+            return
+        from opentelemetry import trace as _trace
+
+        active = _trace.get_current_span()
+        if active is None or not active.get_span_context().is_valid:
+            return
+        attrs = event.attributes
+        active.add_event(
+            event.event_type,
+            attributes={k: str(v) for k, v in attrs.items()} if attrs else {},
+        )
+
+    def register_span_enricher(self, func: Callable[[BaseEvent], dict]) -> None:
+        """Register a callable that enriches OTel span attributes at span creation time.
+
+        Called for every TaskCreated event (and TaskStarted fallback). The callable receives the
+        event and must return a dict of additional OTel attributes to merge. Exceptions are logged
+        at DEBUG level so faulty extractors cannot crash the dispatch loop.
+        """
+        self._span_attribute_extractors.append(func)
+
+    @contextmanager
+    def span_scope(self, name: str, attributes: dict | None = None):
+        """Create a named span, make it the active OTel context for the duration.
+
+        Any emit(TaskCreated) calls made while this scope is active will capture this span as the
+        parent, so task spans become structural children.
+
+        No-op when telemetry has not been started (self._tracer is None).
+        """
+        if self._tracer is None:
+            yield
+            return
+        from opentelemetry import context as otel_context
+        from opentelemetry import trace as trace_mod
+
+        _active = trace_mod.get_current_span()
+        _ctx = (
+            None
+            if _active.get_span_context().is_valid
+            else (trace_mod.set_span_in_context(self._session_span) if self._session_span else None)
+        )
+        span = self._tracer.start_span(name, context=_ctx, attributes=attributes or {})
+        token = otel_context.attach(trace_mod.set_span_in_context(span))
+        try:
+            yield
+        finally:
+            otel_context.detach(token)
+            span.end()
 
     def register_adapter(self, adapter: TelemetryAdapter) -> None:
         """Register a backend telemetry adapter.
@@ -343,6 +474,97 @@ class TelemetryManager:
         if self._span_exporter is None:
             return ()
         return self._span_exporter.get_finished_spans()
+
+    def export_as_otlp(self, path: str | None = None) -> str:
+        """Export finished spans as a valid OTLP JSON string.
+
+        Produces output compatible with Jaeger, Tempo, Grafana, and any standard
+        OTel visualizer. The JSONL checkpoint is RHAPSODY's internal analysis format
+        and is intentionally not OTLP-compliant; this method provides the standard
+        export path alongside it.
+
+        Args:
+            path: If given, write the JSON to this file (parent dirs created as needed).
+
+        Returns:
+            OTLP JSON string (``{"resourceSpans": [...]}``)
+        """
+        spans = self.read_traces()
+
+        def _typed_kv(k: str, v) -> dict:
+            if isinstance(v, bool):
+                return {"key": k, "value": {"boolValue": v}}
+            if isinstance(v, int):
+                return {"key": k, "value": {"intValue": str(v)}}
+            if isinstance(v, float):
+                return {"key": k, "value": {"doubleValue": v}}
+            return {"key": k, "value": {"stringValue": str(v)}}
+
+        otlp_spans = []
+        for s in spans:
+            try:
+                status_code = s.status.status_code.value
+            except AttributeError:
+                status_code = 0
+            status_obj: dict = {"code": status_code}
+            if s.status.description:
+                status_obj["message"] = s.status.description
+
+            try:
+                kind = s.kind.value
+            except AttributeError:
+                kind = 0
+
+            span_dict: dict = {
+                "traceId": format(s.context.trace_id, "032x"),
+                "spanId": format(s.context.span_id, "016x"),
+                "name": s.name,
+                "kind": kind,
+                "startTimeUnixNano": str(s.start_time) if s.start_time else "0",
+                "endTimeUnixNano": str(s.end_time) if s.end_time else "0",
+                "attributes": [_typed_kv(k, v) for k, v in (s.attributes or {}).items()],
+                "status": status_obj,
+            }
+            if s.parent:
+                span_dict["parentSpanId"] = format(s.parent.span_id, "016x")
+            if s.events:
+                span_dict["events"] = [
+                    {
+                        "timeUnixNano": str(e.timestamp),
+                        "name": e.name,
+                        "attributes": [_typed_kv(k, v) for k, v in (e.attributes or {}).items()],
+                    }
+                    for e in s.events
+                ]
+            otlp_spans.append(span_dict)
+
+        payload = {
+            "resourceSpans": [
+                {
+                    "resource": {
+                        "attributes": [
+                            _typed_kv("service.name", "rhapsody"),
+                            _typed_kv("session_id", self._session_id),
+                        ]
+                    },
+                    "scopeSpans": [
+                        {
+                            "scope": {"name": "rhapsody"},
+                            "spans": otlp_spans,
+                        }
+                    ],
+                }
+            ]
+        }
+
+        result = json.dumps(payload)
+
+        if path is not None:
+            p = Path(path)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(result)
+
+        return result
 
     # ------------------------------------------------------------------
     # Convenience methods
@@ -726,6 +948,7 @@ class TelemetryManager:
 
     async def _dispatch_loop(self) -> None:
         """Background task: drain queue in batches, update OTel instruments, notify subscribers."""
+        from opentelemetry import context as otel_context
         from opentelemetry import trace
 
         _batch_size = 500
@@ -740,7 +963,7 @@ class TelemetryManager:
                     if item is _STOP_SENTINEL:
                         self._queue.task_done()
                         if batch:
-                            self._flush_batch(batch, trace)
+                            self._flush_batch(batch, trace, otel_context)
                             for _ in batch:
                                 self._queue.task_done()
                         return
@@ -757,7 +980,7 @@ class TelemetryManager:
                     return
                 batch.append(item)
 
-            self._flush_batch(batch, trace)
+            self._flush_batch(batch, trace, otel_context)
             for _ in batch:
                 self._queue.task_done()  # task_done AFTER processing (Fix 1)
 
@@ -766,12 +989,12 @@ class TelemetryManager:
             if len(batch) == _batch_size:
                 await asyncio.sleep(0)
 
-    def _flush_batch(self, batch: list[BaseEvent], trace_mod: Any) -> None:
+    def _flush_batch(self, batch: list[BaseEvent], trace_mod: Any, otel_context: Any) -> None:
         """Process a collected batch: OTel instruments, JSONL write, subscribers."""
         for event in batch:
             self._event_log.append(event)
             try:
-                self._process_event(event, trace_mod)
+                self._process_event(event, trace_mod, otel_context)
             except Exception:
                 logger.exception("Error processing telemetry event %s", event.event_type)
 
@@ -808,7 +1031,7 @@ class TelemetryManager:
         if lines:
             self._checkpoint_file.write("\n".join(lines) + "\n")
 
-    def _process_event(self, event: BaseEvent, trace_mod: Any) -> None:
+    def _process_event(self, event: BaseEvent, trace_mod: Any, otel_context: Any) -> None:
         """Translate a RHAPSODY event into OTel instrument calls and span lifecycle."""
         etype = event.event_type
         attrs = {"session_id": event.session_id, "backend": event.backend or ""}
@@ -822,10 +1045,22 @@ class TelemetryManager:
                 "executable": executable,
                 "task_type": task_type,
             }
-            ctx = trace_mod.set_span_in_context(self._session_span) if self._session_span else None
-            self._active_spans[event.task_id] = self._tracer.start_span(
-                "task", context=ctx, attributes=a
-            )
+            for extractor in self._span_attribute_extractors:
+                try:
+                    a.update(extractor(event))
+                except Exception:
+                    logger.debug("span attribute extractor failed", exc_info=True)
+            _ctx = self._task_contexts.pop(event.task_id, None)
+            if _ctx is not None:
+                _token = otel_context.attach(_ctx)
+                try:
+                    self._active_spans[event.task_id] = self._tracer.start_span(
+                        "task", attributes=a
+                    )
+                finally:
+                    otel_context.detach(_token)
+            else:
+                self._active_spans[event.task_id] = self._tracer.start_span("task", attributes=a)
 
         elif etype == "TaskSubmitted":
             self._c_submitted.add(1, {**attrs, "task_id": event.task_id})
@@ -843,14 +1078,27 @@ class TelemetryManager:
             self._g_running.add(1, a)
             if event.task_id not in self._active_spans:
                 # Fallback: TaskCreated was never seen (incomplete lifecycle).
-                ctx = (
-                    trace_mod.set_span_in_context(self._session_span)
-                    if self._session_span
-                    else None
-                )
-                self._active_spans[event.task_id] = self._tracer.start_span(
-                    "task", context=ctx, attributes=a
-                )
+                # Use a_span copy so metric attributes (a) are not polluted with
+                # workflow_id or other span-only extractor fields.
+                a_span = dict(a)
+                for extractor in self._span_attribute_extractors:
+                    try:
+                        a_span.update(extractor(event))
+                    except Exception:
+                        logger.debug("span attribute extractor failed", exc_info=True)
+                _ctx = self._task_contexts.pop(event.task_id, None)
+                if _ctx is not None:
+                    _token = otel_context.attach(_ctx)
+                    try:
+                        self._active_spans[event.task_id] = self._tracer.start_span(
+                            "task", attributes=a_span
+                        )
+                    finally:
+                        otel_context.detach(_token)
+                else:
+                    self._active_spans[event.task_id] = self._tracer.start_span(
+                        "task", attributes=a_span
+                    )
 
         elif etype == "TaskCompleted":
             executable = event.attributes.get("executable", "")
@@ -867,12 +1115,7 @@ class TelemetryManager:
             if span is not None:
                 self._g_running.add(-1, a)
             else:
-                ctx = (
-                    trace_mod.set_span_in_context(self._session_span)
-                    if self._session_span
-                    else None
-                )
-                span = self._tracer.start_span("task", context=ctx, attributes=a)
+                span = self._tracer.start_span("task", attributes=a)
             span.set_attribute("status", "completed")
             span.set_attribute("executable", executable)
             span.set_attribute("task_type", task_type)
@@ -898,12 +1141,7 @@ class TelemetryManager:
             if span is not None:
                 self._g_running.add(-1, a)
             else:
-                ctx = (
-                    trace_mod.set_span_in_context(self._session_span)
-                    if self._session_span
-                    else None
-                )
-                span = self._tracer.start_span("task", context=ctx, attributes=a)
+                span = self._tracer.start_span("task", attributes=a)
             span.set_attribute("status", "failed")
             span.set_attribute("error_type", error_type)
             span.set_attribute("executable", executable)
@@ -929,12 +1167,7 @@ class TelemetryManager:
             if span is not None:
                 self._g_running.add(-1, a)
             else:
-                ctx = (
-                    trace_mod.set_span_in_context(self._session_span)
-                    if self._session_span
-                    else None
-                )
-                span = self._tracer.start_span("task", context=ctx, attributes=a)
+                span = self._tracer.start_span("task", attributes=a)
             span.set_attribute("status", "canceled")
             span.set_attribute("executable", executable)
             span.set_attribute("task_type", task_type)
@@ -945,7 +1178,7 @@ class TelemetryManager:
             self._completed_span_ctx[event.task_id] = span.get_span_context()
 
         elif etype == "SessionStarted":
-            self._session_span = self._tracer.start_span("session", attributes=attrs)
+            pass  # session span created synchronously in start() for immediate availability
 
         elif etype == "SessionEnded":
             if self._session_span:

--- a/src/rhapsody/telemetry/manager.py
+++ b/src/rhapsody/telemetry/manager.py
@@ -112,6 +112,7 @@ class TelemetryManager:
         # Active OTel spans keyed by task_id
         self._active_spans: dict[str, Any] = {}
         self._session_span: Any = None
+        self._completed_session_ctx: Any = None  # snapshot after session span ends
 
         # Wall-clock time recorded when RUNNING is first seen for each task.
         self._task_start_times: dict[str, float] = {}
@@ -623,19 +624,27 @@ class TelemetryManager:
         Must be called AFTER _process_event() so that spans have been created/ended.
 
         Correlation rules:
-        - TaskStarted/Completed/Failed  → trace_id + span_id of the task span
-        - SessionStarted/SessionEnded   → trace_id + span_id of the session span
-        - TaskSubmitted/TaskQueued      → session trace_id only (span not yet created),
-                                          span_id = None (OTel-aligned: event belongs to
-                                          the trace but precedes the task span)
-        - ResourceUpdate                → (None, None) — node metric, not task-correlated
+        - TaskCreated/Submitted/Queued/Started/Completed/Failed → task span
+        - SessionStarted/SessionEnded   → session span
+        - ResourceUpdate                → session span
         """
         span_ctx = None
 
-        if event.event_type == "TaskStarted":
+        if event.event_type in ("TaskCreated", "TaskStarted", "TaskSubmitted", "TaskQueued"):
             span = self._active_spans.get(event.task_id)
             if span:
                 span_ctx = span.get_span_context()
+            else:
+                # Same-batch scenario: _process_event(TaskCompleted/Failed/Canceled) already
+                # ran and moved the span_ctx to _completed_span_ctx. Use .get (not .pop) —
+                # the terminal event's own _span_ids_for_event call will pop it.
+                span_ctx = self._completed_span_ctx.get(event.task_id)
+            if span_ctx is None and event.event_type in ("TaskSubmitted", "TaskQueued"):
+                # Fallback: TaskCreated not yet processed — attach to session trace only.
+                if self._session_span:
+                    session_ctx = self._session_span.get_span_context()
+                    if session_ctx.is_valid:
+                        return hex(session_ctx.trace_id), None
 
         elif event.event_type in ("TaskCompleted", "TaskFailed", "TaskCanceled"):
             span_ctx = self._completed_span_ctx.pop(event.task_id, None)
@@ -643,14 +652,9 @@ class TelemetryManager:
         elif event.event_type in ("SessionStarted", "SessionEnded"):
             if self._session_span:
                 span_ctx = self._session_span.get_span_context()
-
-        elif event.event_type in ("TaskSubmitted", "TaskQueued"):
-            # No task span exists yet — attach to the session trace so the event
-            # can be stitched into a full timeline; span_id remains None.
-            if self._session_span:
-                session_ctx = self._session_span.get_span_context()
-                if session_ctx.is_valid:
-                    return hex(session_ctx.trace_id), None
+            elif event.event_type == "SessionEnded":
+                # Same-batch: _process_event already ended _session_span; use snapshot.
+                span_ctx = self._completed_session_ctx
 
         elif event.event_type == "ResourceUpdate":
             # Node/GPU metric belongs to the session scope — attach to the session
@@ -789,9 +793,23 @@ class TelemetryManager:
     def _process_event(self, event: BaseEvent, trace_mod: Any) -> None:
         """Translate a RHAPSODY event into OTel instrument calls and span lifecycle."""
         etype = event.event_type
-        attrs = {"session_id": event.session_id, "backend": event.backend}
+        attrs = {"session_id": event.session_id, "backend": event.backend or ""}
 
-        if etype == "TaskSubmitted":
+        if etype == "TaskCreated":
+            executable = event.attributes.get("executable", "")
+            task_type = event.attributes.get("task_type", "")
+            a = {
+                **attrs,
+                "task_id": event.task_id,
+                "executable": executable,
+                "task_type": task_type,
+            }
+            ctx = trace_mod.set_span_in_context(self._session_span) if self._session_span else None
+            self._active_spans[event.task_id] = self._tracer.start_span(
+                "task", context=ctx, attributes=a
+            )
+
+        elif etype == "TaskSubmitted":
             self._c_submitted.add(1, {**attrs, "task_id": event.task_id})
 
         elif etype == "TaskStarted":
@@ -805,10 +823,16 @@ class TelemetryManager:
             }
             self._c_started.add(1, a)
             self._g_running.add(1, a)
-            ctx = trace_mod.set_span_in_context(self._session_span) if self._session_span else None
-            self._active_spans[event.task_id] = self._tracer.start_span(
-                "task", context=ctx, attributes=a
-            )
+            if event.task_id not in self._active_spans:
+                # Fallback: TaskCreated was never seen (incomplete lifecycle).
+                ctx = (
+                    trace_mod.set_span_in_context(self._session_span)
+                    if self._session_span
+                    else None
+                )
+                self._active_spans[event.task_id] = self._tracer.start_span(
+                    "task", context=ctx, attributes=a
+                )
 
         elif etype == "TaskCompleted":
             executable = event.attributes.get("executable", "")
@@ -904,6 +928,7 @@ class TelemetryManager:
 
         elif etype == "SessionEnded":
             if self._session_span:
+                self._completed_session_ctx = self._session_span.get_span_context()
                 self._session_span.end()
                 self._session_span = None
 

--- a/src/rhapsody/telemetry/manager.py
+++ b/src/rhapsody/telemetry/manager.py
@@ -37,6 +37,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Pushed onto the queue by stop() after queue.join() to unblock the dispatch loop cleanly.
+_STOP_SENTINEL = object()
+
 
 class TelemetryManager:
     """Central telemetry orchestrator for a RHAPSODY session.
@@ -71,7 +74,7 @@ class TelemetryManager:
         checkpoint_path: str | None = None,
     ) -> None:
         self._session_id = session_id
-        self._queue: asyncio.Queue[BaseEvent] = asyncio.Queue()
+        self._queue: asyncio.Queue = asyncio.Queue()
         self._subscribers: list[Callable[[BaseEvent], Any]] = []
         self._adapters: list[TelemetryAdapter] = []
         self._running = False
@@ -188,6 +191,13 @@ class TelemetryManager:
         )
 
         self._running = False
+        # Drain all in-flight events before signalling the dispatch loop to exit.
+        # emit() is now a no-op (guard on _running), so no new events can arrive.
+        try:
+            await asyncio.wait_for(self._queue.join(), timeout=5.0)
+        except asyncio.TimeoutError:
+            logger.warning("Telemetry queue did not drain cleanly within timeout")
+        self._queue.put_nowait(_STOP_SENTINEL)
 
         for adapter in self._adapters:
             try:
@@ -228,8 +238,10 @@ class TelemetryManager:
     def emit(self, event: BaseEvent) -> None:
         """Enqueue an event for processing.
 
-        Non-blocking, O(1), safe to call from any context.
+        Non-blocking, O(1), safe to call from any context. No-op once stop() has been called.
         """
+        if not self._running:
+            return
         self._queue.put_nowait(event)
 
     def subscribe(self, callback: Callable[[BaseEvent], Any]) -> None:
@@ -691,45 +703,88 @@ class TelemetryManager:
     # ------------------------------------------------------------------
 
     async def _dispatch_loop(self) -> None:
-        """Background task: drain queue, update OTel instruments, notify subscribers."""
+        """Background task: drain queue in batches, update OTel instruments, notify subscribers."""
         from opentelemetry import trace
 
-        while self._running or not self._queue.empty():
-            try:
-                event = await asyncio.wait_for(self._queue.get(), timeout=0.05)
-            except asyncio.TimeoutError:
-                continue
+        _batch_size = 500
 
-            # Keep raw log for convenience methods
+        while True:
+            # Fast path: drain up to _batch_size events without yielding to the event loop.
+            # get_nowait() is a plain deque.popleft() — zero asyncio scheduling overhead.
+            batch: list[BaseEvent] = []
+            try:
+                while len(batch) < _batch_size:
+                    item = self._queue.get_nowait()
+                    if item is _STOP_SENTINEL:
+                        self._queue.task_done()
+                        if batch:
+                            self._flush_batch(batch, trace)
+                            for _ in batch:
+                                self._queue.task_done()
+                        return
+                    batch.append(item)
+            except asyncio.QueueEmpty:
+                pass
+
+            if not batch:
+                # Slow path: queue was empty — wait without a timeout.
+                # Plain queue.get(), no wait_for(), no timer handle, no Task allocation.
+                item = await self._queue.get()
+                if item is _STOP_SENTINEL:
+                    self._queue.task_done()
+                    return
+                batch.append(item)
+
+            self._flush_batch(batch, trace)
+            for _ in batch:
+                self._queue.task_done()  # task_done AFTER processing (Fix 1)
+
+            # Yield only when a full batch was drained — queue likely has more items.
+            # Partial batch means queue is exhausted; await queue.get() yields naturally.
+            if len(batch) == _batch_size:
+                await asyncio.sleep(0)
+
+    def _flush_batch(self, batch: list[BaseEvent], trace_mod: Any) -> None:
+        """Process a collected batch: OTel instruments, JSONL write, subscribers."""
+        for event in batch:
             self._event_log.append(event)
-
             try:
-                self._process_event(event, trace)
+                self._process_event(event, trace_mod)
             except Exception:
                 logger.exception("Error processing telemetry event %s", event.event_type)
 
-            # Write event line to JSONL file — enriched with OTel correlation IDs
-            if self._checkpoint_file is not None:
-                try:
-                    d = dataclasses.asdict(event)
-                    trace_id, span_id = self._span_ids_for_event(event)
-                    d["trace_id"] = trace_id
-                    d["span_id"] = span_id
-                    d["name"] = event.event_type  # OTel-compatible alias
-                    self._write_line("event", d)
-                except Exception:
-                    logger.debug("Failed to write event to checkpoint file", exc_info=True)
+        if self._checkpoint_file is not None:
+            self._write_batch(batch)
 
-            for sub in self._subscribers:
-                try:
-                    if asyncio.iscoroutinefunction(sub):
-                        asyncio.create_task(sub(event))
-                    else:
-                        sub(event)
-                except Exception:
-                    logger.debug("Subscriber raised exception", exc_info=True)
+        if self._subscribers:
+            for event in batch:
+                for sub in self._subscribers:
+                    try:
+                        if asyncio.iscoroutinefunction(sub):
+                            asyncio.create_task(sub(event))
+                        else:
+                            sub(event)
+                    except Exception:
+                        logger.debug("Subscriber raised exception", exc_info=True)
 
-            self._queue.task_done()
+    def _write_batch(self, events: list[BaseEvent]) -> None:
+        """Write a batch of events to JSONL in a single file.write() call."""
+        lines = []
+        for event in events:
+            try:
+                # fields() + getattr: shallow copy that captures init=False class-level
+                # fields (e.g. event_type) which vars()/.__dict__ misses on frozen subclasses.
+                d = {f.name: getattr(event, f.name) for f in dataclasses.fields(event)}
+                trace_id, span_id = self._span_ids_for_event(event)
+                d["trace_id"] = trace_id
+                d["span_id"] = span_id
+                d["name"] = event.event_type
+                d["section"] = "event"
+                lines.append(json.dumps(d, default=str))
+            except Exception:
+                logger.debug("Failed to serialize event for checkpoint", exc_info=True)
+        if lines:
+            self._checkpoint_file.write("\n".join(lines) + "\n")
 
     def _process_event(self, event: BaseEvent, trace_mod: Any) -> None:
         """Translate a RHAPSODY event into OTel instrument calls and span lifecycle."""
@@ -875,7 +930,7 @@ class TelemetryManager:
         filename = f"{self._session_id}.{ts}.telemetry.jsonl"
         filepath = path / filename
         try:
-            self._checkpoint_file = open(filepath, "w", buffering=1)  # line-buffered
+            self._checkpoint_file = open(filepath, "w", buffering=131072)  # 128 KB block buffer
             logger.info("Telemetry checkpoint file: %s", filepath)
         except OSError:
             logger.exception("Could not open telemetry checkpoint file %s", filepath)

--- a/src/rhapsody/telemetry/manager.py
+++ b/src/rhapsody/telemetry/manager.py
@@ -528,6 +528,11 @@ class TelemetryManager:
                 return {"key": k, "value": {"intValue": str(v)}}
             if isinstance(v, float):
                 return {"key": k, "value": {"doubleValue": v}}
+            if isinstance(v, (list, tuple)):
+                return {
+                    "key": k,
+                    "value": {"arrayValue": {"values": [_typed_kv("", e)["value"] for e in v]}},
+                }
             return {"key": k, "value": {"stringValue": str(v)}}
 
         otlp_spans = []
@@ -568,15 +573,12 @@ class TelemetryManager:
                 ]
             otlp_spans.append(span_dict)
 
+        res_attrs = dict(self._tracer_provider.resource.attributes)
+        res_attrs.setdefault("session_id", self._session_id)
         payload = {
             "resourceSpans": [
                 {
-                    "resource": {
-                        "attributes": [
-                            _typed_kv("service.name", "rhapsody"),
-                            _typed_kv("session_id", self._session_id),
-                        ]
-                    },
+                    "resource": {"attributes": [_typed_kv(k, v) for k, v in res_attrs.items()]},
                     "scopeSpans": [
                         {
                             "scope": {"name": "rhapsody"},
@@ -1059,7 +1061,13 @@ class TelemetryManager:
             except Exception:
                 logger.debug("Failed to serialize event for checkpoint", exc_info=True)
         if lines:
-            self._checkpoint_file.write("\n".join(lines) + "\n")
+            try:
+                self._checkpoint_file.write("\n".join(lines) + "\n")
+            except OSError:
+                logger.warning(
+                    "Telemetry checkpoint write failed; events lost for this batch",
+                    exc_info=True,
+                )
 
     def _process_event(self, event: BaseEvent, trace_mod: Any, otel_context: Any) -> None:
         """Translate a RHAPSODY event into OTel instrument calls and span lifecycle."""
@@ -1206,6 +1214,11 @@ class TelemetryManager:
             span.set_status(trace_mod.StatusCode.ERROR)
             span.end()
             self._completed_span_ctx[event.task_id] = span.get_span_context()
+
+        elif etype == "TaskQueued":
+            span = self._active_spans.get(event.task_id)
+            if span is not None and span.is_recording():
+                span.add_event("TaskQueued", attributes={"task_id": event.task_id})
 
         elif etype == "SessionStarted":
             pass  # session span created synchronously in start() for immediate availability

--- a/src/rhapsody/telemetry/manager.py
+++ b/src/rhapsody/telemetry/manager.py
@@ -662,6 +662,24 @@ class TelemetryManager:
             if self._session_span:
                 span_ctx = self._session_span.get_span_context()
 
+        else:
+            # Generic fallback for custom/extension events (e.g.
+            # any user-emitted event via telemetry.emit()).
+            # Correlation by duck typing:
+            #   - has task_id → belongs to the task span (active or recently completed)
+            #   - no task_id  → belongs to the session span
+            # Use .get not .pop — custom events are never terminal; they never own the
+            # span lifecycle.
+            task_id = getattr(event, "task_id", None)
+            if task_id:
+                span = self._active_spans.get(task_id)
+                if span:
+                    span_ctx = span.get_span_context()
+                else:
+                    span_ctx = self._completed_span_ctx.get(task_id)
+            elif self._session_span:
+                span_ctx = self._session_span.get_span_context()
+
         if span_ctx is None or not span_ctx.is_valid:
             return None, None
         return hex(span_ctx.trace_id), hex(span_ctx.span_id)

--- a/src/rhapsody/telemetry/manager.py
+++ b/src/rhapsody/telemetry/manager.py
@@ -34,6 +34,10 @@ from rhapsody.telemetry.events import TaskSubmitted
 from rhapsody.telemetry.events import make_event
 
 if TYPE_CHECKING:
+    from opentelemetry.sdk.metrics.export import MetricReader
+    from opentelemetry.sdk.resources import Resource as OtelResource
+    from opentelemetry.sdk.trace import SpanProcessor
+
     from rhapsody.telemetry.adapters.base import TelemetryAdapter
 
 logger = logging.getLogger(__name__)
@@ -108,6 +112,9 @@ class TelemetryManager:
         session_id: str,
         checkpoint_interval: float | None = None,
         checkpoint_path: str | None = None,
+        span_processors: list[SpanProcessor] | None = None,
+        metric_readers: list[MetricReader] | None = None,
+        resource: OtelResource | None = None,
     ) -> None:
         self._session_id = session_id
         self._queue: asyncio.Queue = asyncio.Queue()
@@ -173,6 +180,15 @@ class TelemetryManager:
         # Stored so it can be properly detached in stop().
         self._session_ctx_token: Any = None
 
+        # Caller-supplied OTel extension points wired into RHAPSODY's internal providers
+        # at start() time alongside SpanBuffer / InMemoryMetricReader.
+        # Callers own exporter construction; RHAPSODY never imports specific exporters.
+        self._extra_span_processors: list = list(span_processors or [])
+        self._extra_metric_readers: list = list(metric_readers or [])
+        # Optional Resource override. None → Resource.create() in start(), which reads
+        # OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES from the environment automatically.
+        self._resource: Any = resource
+
     # ------------------------------------------------------------------
     # Public properties
     # ------------------------------------------------------------------
@@ -190,14 +206,28 @@ class TelemetryManager:
         """Start the telemetry manager: set up OTel SDK, open checkpoint file, start loops."""
         from opentelemetry.sdk.metrics import MeterProvider
         from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+        from opentelemetry.sdk.resources import Resource
         from opentelemetry.sdk.trace import TracerProvider
         from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 
+        # Resource.create() reads OTEL_SERVICE_NAME / OTEL_RESOURCE_ATTRIBUTES from the
+        # environment automatically; the passed dict provides fallback defaults only.
+        _resource = self._resource or Resource.create(
+            {"service.name": "rhapsody", "session_id": self._session_id}
+        )
+
         self._metric_reader = InMemoryMetricReader()
         self._span_exporter = SpanBuffer()
-        self._meter_provider = MeterProvider(metric_readers=[self._metric_reader])
-        self._tracer_provider = TracerProvider()
+
+        self._meter_provider = MeterProvider(
+            metric_readers=[self._metric_reader] + self._extra_metric_readers,
+            resource=_resource,
+        )
+        self._tracer_provider = TracerProvider(resource=_resource)
         self._tracer_provider.add_span_processor(SimpleSpanProcessor(self._span_exporter))
+        for proc in self._extra_span_processors:
+            self._tracer_provider.add_span_processor(proc)
+
         self._meter = self._meter_provider.get_meter("rhapsody")
         self._tracer = self._tracer_provider.get_tracer("rhapsody")
 

--- a/src/rhapsody/telemetry/manager.py
+++ b/src/rhapsody/telemetry/manager.py
@@ -878,6 +878,7 @@ class TelemetryManager:
             span.set_attribute("task_type", task_type)
             if event.attributes.get("incomplete_lifecycle"):
                 span.set_attribute("incomplete_lifecycle", True)
+            span.set_status(trace_mod.StatusCode.OK)
             span.end()
             self._completed_span_ctx[event.task_id] = span.get_span_context()
 
@@ -909,6 +910,7 @@ class TelemetryManager:
             span.set_attribute("task_type", task_type)
             if event.attributes.get("incomplete_lifecycle"):
                 span.set_attribute("incomplete_lifecycle", True)
+            span.set_status(trace_mod.StatusCode.ERROR, error_type)
             span.end()
             self._completed_span_ctx[event.task_id] = span.get_span_context()
 
@@ -938,6 +940,7 @@ class TelemetryManager:
             span.set_attribute("task_type", task_type)
             if event.attributes.get("incomplete_lifecycle"):
                 span.set_attribute("incomplete_lifecycle", True)
+            span.set_status(trace_mod.StatusCode.ERROR)
             span.end()
             self._completed_span_ctx[event.task_id] = span.get_span_context()
 
@@ -1023,6 +1026,8 @@ class TelemetryManager:
                 "start_time_s": s.start_time / 1e9 if s.start_time else None,
                 "end_time_s": s.end_time / 1e9 if s.end_time else None,
                 "duration_ms": round(dur, 3) if dur is not None else None,
+                "status_code": s.status.status_code.name,
+                "status_description": s.status.description or None,
                 "attributes": dict(s.attributes or {}),
             }
             try:

--- a/tests/unit/telemetry/test_manager.py
+++ b/tests/unit/telemetry/test_manager.py
@@ -522,6 +522,69 @@ class TestCheckpointFile:
         await m.stop()
         assert m._checkpoint_file is None
 
+    async def test_custom_task_event_has_span_ids(self):
+        """Custom events with task_id must carry the same trace/span as the task span."""
+        from rhapsody.telemetry.events import define_event
+
+        TaskResolved = define_event("asyncflow.TaskResolved")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            m = TelemetryManager(session_id="custom-task-ev", checkpoint_path=tmpdir)
+            await m.start()
+            m.emit(
+                make_event(
+                    TaskCreated, session_id="custom-task-ev", backend="concurrent", task_id="t1"
+                )
+            )
+            m.emit(
+                make_event(
+                    TaskResolved, session_id="custom-task-ev", backend="concurrent", task_id="t1"
+                )
+            )
+            m.emit(
+                make_event(
+                    TaskCompleted,
+                    session_id="custom-task-ev",
+                    backend="concurrent",
+                    task_id="t1",
+                    duration_seconds=0.1,
+                )
+            )
+            await asyncio.sleep(0.1)
+            await m.stop()
+
+            filepath = os.path.join(tmpdir, os.listdir(tmpdir)[0])
+            rows = [json.loads(l) for l in open(filepath)]
+            evs = {r["event_type"]: r for r in rows if r.get("section") == "event"}
+
+            assert evs["asyncflow.TaskResolved"]["trace_id"] is not None
+            assert evs["asyncflow.TaskResolved"]["span_id"] is not None
+            assert (
+                evs["asyncflow.TaskResolved"]["span_id"]
+                == evs["TaskCreated"]["span_id"]
+                == evs["TaskCompleted"]["span_id"]
+            )
+
+    async def test_custom_session_event_has_trace_id(self):
+        """Custom events without task_id must carry the session trace/span IDs."""
+        from rhapsody.telemetry.events import define_event
+
+        SessionNote = define_event("user.SessionNote")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            m = TelemetryManager(session_id="custom-sess-ev", checkpoint_path=tmpdir)
+            await m.start()
+            m.emit(make_event(SessionNote, session_id="custom-sess-ev", backend="concurrent"))
+            await asyncio.sleep(0.1)
+            await m.stop()
+
+            filepath = os.path.join(tmpdir, os.listdir(tmpdir)[0])
+            rows = [json.loads(l) for l in open(filepath)]
+            evs = {r["event_type"]: r for r in rows if r.get("section") == "event"}
+
+            assert evs["user.SessionNote"]["trace_id"] is not None
+            assert evs["user.SessionNote"]["span_id"] is not None
+
 
 class TestTaskStateTransitions:
     """Verify _on_task_state_change handles all RUNNING / DONE / FAILED orderings.

--- a/tests/unit/telemetry/test_manager.py
+++ b/tests/unit/telemetry/test_manager.py
@@ -10,7 +10,9 @@ import pytest
 
 pytest.importorskip("opentelemetry", reason="opentelemetry-sdk not installed")
 
+from rhapsody.telemetry.events import TaskCanceled
 from rhapsody.telemetry.events import TaskCompleted
+from rhapsody.telemetry.events import TaskCreated
 from rhapsody.telemetry.events import TaskFailed
 from rhapsody.telemetry.events import TaskQueued
 from rhapsody.telemetry.events import TaskStarted
@@ -175,6 +177,127 @@ class TestSpans:
         assert session_spans[0].end_time is not None
         # prevent double-stop in fixture teardown
         manager._telemetry = None  # type: ignore[attr-defined]
+
+    async def test_session_ended_has_trace_and_span_ids(self):
+        """SessionEnded must carry full trace+span IDs even though the span ends in the same
+        batch."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            m = TelemetryManager(session_id="se-ids", checkpoint_path=tmpdir)
+            await m.start()
+            await m.stop()
+
+            filepath = os.path.join(tmpdir, os.listdir(tmpdir)[0])
+            events = [json.loads(l) for l in open(filepath) if json.loads(l)["section"] == "event"]
+            ended = next(e for e in events if e["event_type"] == "SessionEnded")
+            assert ended["trace_id"] is not None, "SessionEnded: trace_id must not be null"
+            assert ended["span_id"] is not None, "SessionEnded: span_id must not be null"
+
+    async def test_task_span_created_at_task_created(self, manager):
+        """Span must exist with valid trace/span context immediately after TaskCreated."""
+        manager.emit(
+            make_event(TaskCreated, session_id="test-session", backend="concurrent", task_id="t1")
+        )
+        await asyncio.sleep(0.1)
+        assert "t1" in manager._active_spans
+        ctx = manager._active_spans["t1"].get_span_context()
+        assert ctx.is_valid
+        assert ctx.trace_id != 0
+        assert ctx.span_id != 0
+
+    async def test_full_lifecycle_span_ids_consistent(self, manager):
+        """All lifecycle events for a task must reference the same span_id."""
+        received_ids: dict[str, tuple] = {}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            m = TelemetryManager(session_id="ids-test", checkpoint_path=tmpdir)
+            await m.start()
+            for etype, kwargs in [
+                (TaskCreated, {}),
+                (TaskSubmitted, {}),
+                (TaskQueued, {}),
+                (TaskStarted, {}),
+                (TaskCompleted, {"duration_seconds": 0.1}),
+            ]:
+                m.emit(
+                    make_event(
+                        etype, session_id="ids-test", backend="concurrent", task_id="t1", **kwargs
+                    )
+                )
+            await asyncio.sleep(0.1)
+            await m.stop()
+
+            filepath = os.path.join(tmpdir, os.listdir(tmpdir)[0])
+            events = [
+                json.loads(line)
+                for line in open(filepath)
+                if json.loads(line)["section"] == "event"
+            ]
+            lifecycle = {
+                e["event_type"]: e
+                for e in events
+                if e["event_type"]
+                in ("TaskCreated", "TaskSubmitted", "TaskQueued", "TaskStarted", "TaskCompleted")
+            }
+
+            for etype, e in lifecycle.items():
+                assert e["trace_id"] is not None, f"{etype}: trace_id must not be null"
+                assert e["span_id"] is not None, f"{etype}: span_id must not be null"
+
+            span_ids = {e["span_id"] for e in lifecycle.values()}
+            assert len(span_ids) == 1, (
+                f"All lifecycle events must share one span_id, got {span_ids}"
+            )
+
+    @pytest.mark.parametrize(
+        "terminal_cls,terminal_kwargs,terminal_etype",
+        [
+            (TaskFailed, {"duration_seconds": 0.1, "error_type": "RuntimeError"}, "TaskFailed"),
+            (TaskCanceled, {"duration_seconds": 0.1}, "TaskCanceled"),
+        ],
+    )
+    async def test_failed_and_canceled_same_batch_span_ids(
+        self, terminal_cls, terminal_kwargs, terminal_etype
+    ):
+        """TaskFailed and TaskCanceled must carry the same span_id as the rest of the lifecycle even
+        when all events land in the same batch (same-batch ordering hazard)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            m = TelemetryManager(session_id="fc-ids", checkpoint_path=tmpdir)
+            await m.start()
+            for etype, kwargs in [
+                (TaskCreated, {}),
+                (TaskSubmitted, {}),
+                (TaskQueued, {}),
+                (TaskStarted, {}),
+                (terminal_cls, terminal_kwargs),
+            ]:
+                m.emit(
+                    make_event(
+                        etype, session_id="fc-ids", backend="concurrent", task_id="t1", **kwargs
+                    )
+                )
+            await asyncio.sleep(0.1)
+            await m.stop()
+
+            filepath = os.path.join(tmpdir, os.listdir(tmpdir)[0])
+            events = [
+                json.loads(line)
+                for line in open(filepath)
+                if json.loads(line)["section"] == "event"
+            ]
+            lifecycle = {
+                e["event_type"]: e
+                for e in events
+                if e["event_type"]
+                in ("TaskCreated", "TaskSubmitted", "TaskQueued", "TaskStarted", terminal_etype)
+            }
+
+            for etype, e in lifecycle.items():
+                assert e["trace_id"] is not None, f"{etype}: trace_id must not be null"
+                assert e["span_id"] is not None, f"{etype}: span_id must not be null"
+
+            span_ids = {e["span_id"] for e in lifecycle.values()}
+            assert len(span_ids) == 1, (
+                f"All lifecycle events must share one span_id, got {span_ids}"
+            )
 
 
 class TestSubscriber:

--- a/tests/unit/telemetry/test_manager.py
+++ b/tests/unit/telemetry/test_manager.py
@@ -752,6 +752,162 @@ class TestTaskStateTransitions:
 # ------------------------------------------------------------------
 
 
+class TestOtelInjection:
+    async def test_extra_span_processor_receives_spans(self):
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+        exporter = InMemorySpanExporter()
+        m = TelemetryManager(
+            session_id="inj-spans",
+            span_processors=[SimpleSpanProcessor(exporter)],
+        )
+        await m.start()
+        m.emit(make_event(TaskStarted, session_id="inj-spans", backend="concurrent", task_id="t1"))
+        m.emit(
+            make_event(
+                TaskCompleted,
+                session_id="inj-spans",
+                backend="concurrent",
+                task_id="t1",
+                duration_seconds=0.1,
+            )
+        )
+        await asyncio.sleep(0.1)
+        await m.stop()
+
+        assert any(s.name == "task" for s in exporter.get_finished_spans()), (
+            "injected exporter did not receive the task span"
+        )
+        assert any(s.name == "task" for s in m.read_traces()), (
+            "internal SpanBuffer must still be populated"
+        )
+
+    async def test_extra_metric_reader_receives_metrics(self):
+        from opentelemetry.sdk.metrics.export import InMemoryMetricReader as OtelReader
+
+        reader = OtelReader()
+        m = TelemetryManager(session_id="inj-metrics", metric_readers=[reader])
+        await m.start()
+        m.emit(
+            make_event(TaskSubmitted, session_id="inj-metrics", backend="concurrent", task_id="t1")
+        )
+        await asyncio.sleep(0.1)
+
+        metrics = reader.get_metrics_data()
+        all_names = {
+            metric.name
+            for rm in (metrics.resource_metrics if metrics else [])
+            for sm in rm.scope_metrics
+            for metric in sm.metrics
+        }
+        assert "tasks_submitted" in all_names, (
+            f"tasks_submitted not in injected reader metrics: {all_names}"
+        )
+
+        await m.stop()
+
+
+class TestExportAsOtlp:
+    async def test_custom_resource_attributes_in_otlp(self):
+        from opentelemetry.sdk.resources import Resource
+
+        resource = Resource.create({"service.name": "my-app"})
+        m = TelemetryManager(session_id="otlp-res", resource=resource)
+        await m.start()
+        m.emit(
+            make_event(
+                TaskCompleted,
+                session_id="otlp-res",
+                backend="concurrent",
+                task_id="t1",
+                duration_seconds=0.1,
+            )
+        )
+        await asyncio.sleep(0.1)
+        await m.stop()
+
+        data = json.loads(m.export_as_otlp())
+        res_attrs = {
+            a["key"]: a["value"] for a in data["resourceSpans"][0]["resource"]["attributes"]
+        }
+        assert res_attrs.get("service.name") == {"stringValue": "my-app"}, (
+            f"Expected 'my-app', got {res_attrs.get('service.name')}"
+        )
+
+    async def test_array_attribute_serialized_as_array_value(self):
+        """Tuple span attribute must produce arrayValue in OTLP JSON."""
+        m = TelemetryManager(session_id="otlp-arr")
+        await m.start()
+        m.register_span_enricher(lambda e: {"tags": ("alpha", "beta", "gamma")})
+        m.emit(make_event(TaskCreated, session_id="otlp-arr", backend="concurrent", task_id="t1"))
+        m.emit(
+            make_event(
+                TaskCompleted,
+                session_id="otlp-arr",
+                backend="concurrent",
+                task_id="t1",
+                duration_seconds=0.1,
+            )
+        )
+        await asyncio.sleep(0.1)
+        await m.stop()
+
+        data = json.loads(m.export_as_otlp())
+        spans = data["resourceSpans"][0]["scopeSpans"][0]["spans"]
+        task_span = next(s for s in spans if s["name"] == "task")
+        attrs = {a["key"]: a["value"] for a in task_span["attributes"]}
+
+        assert "arrayValue" in attrs.get("tags", {}), (
+            f"Expected arrayValue for 'tags', got {attrs.get('tags')}"
+        )
+        values = attrs["tags"]["arrayValue"]["values"]
+        assert [v["stringValue"] for v in values] == ["alpha", "beta", "gamma"]
+
+
+class TestTaskQueuedSpanEvent:
+    async def test_task_queued_adds_span_event(self, manager):
+        manager.emit(
+            make_event(TaskCreated, session_id="test-session", backend="concurrent", task_id="t1")
+        )
+        manager.emit(
+            make_event(TaskQueued, session_id="test-session", backend="concurrent", task_id="t1")
+        )
+        manager.emit(
+            make_event(
+                TaskCompleted,
+                session_id="test-session",
+                backend="concurrent",
+                task_id="t1",
+                duration_seconds=0.1,
+            )
+        )
+        await asyncio.sleep(0.1)
+
+        spans = [s for s in manager.read_traces() if s.name == "task"]
+        assert len(spans) == 1
+        span_event_names = [e.name for e in spans[0].events]
+        assert "TaskQueued" in span_event_names
+
+        queued_ev = next(e for e in spans[0].events if e.name == "TaskQueued")
+        assert queued_ev.attributes.get("task_id") == "t1"
+
+    async def test_task_queued_without_prior_created_is_ignored(self, manager):
+        """TaskQueued for an unknown task_id must not crash — span not in _active_spans."""
+        manager.emit(
+            make_event(
+                TaskQueued, session_id="test-session", backend="concurrent", task_id="unknown-t"
+            )
+        )
+        await asyncio.sleep(0.1)
+        assert manager._dispatch_task and not manager._dispatch_task.done()
+
+
+# ------------------------------------------------------------------
+# Helpers to navigate OTel MetricsData
+# ------------------------------------------------------------------
+
+
 def _sum_counter(metrics_data, name: str) -> float:
     total = 0.0
     if metrics_data is None:

--- a/tests/unit/telemetry/test_manager.py
+++ b/tests/unit/telemetry/test_manager.py
@@ -335,7 +335,7 @@ class TestCheckpointFile:
 
             files = os.listdir(tmpdir)
             assert len(files) == 1
-            assert files[0].startswith("rhapsody.session.cp-test.")
+            assert files[0].startswith("cp-test.")
             assert files[0].endswith(".telemetry.jsonl")
 
     async def test_file_contains_all_sections(self):

--- a/tests/unit/telemetry/test_manager.py
+++ b/tests/unit/telemetry/test_manager.py
@@ -146,10 +146,13 @@ class TestSpans:
             )
         )
         await asyncio.sleep(0.1)
+        from opentelemetry.trace import StatusCode
+
         spans = [s for s in manager.read_traces() if s.name == "task"]
         assert len(spans) == 1
         assert spans[0].end_time is not None
         assert spans[0].attributes.get("status") == "completed"
+        assert spans[0].status.status_code == StatusCode.OK
 
     async def test_failed_span_status(self, manager):
         manager.emit(
@@ -166,9 +169,13 @@ class TestSpans:
             )
         )
         await asyncio.sleep(0.1)
+        from opentelemetry.trace import StatusCode
+
         spans = [s for s in manager.read_traces() if s.name == "task"]
         assert spans[0].attributes.get("status") == "failed"
         assert spans[0].attributes.get("error_type") == "ValueError"
+        assert spans[0].status.status_code == StatusCode.ERROR
+        assert spans[0].status.description == "ValueError"
 
     async def test_session_span(self, manager):
         await manager.stop()
@@ -584,6 +591,51 @@ class TestCheckpointFile:
 
             assert evs["user.SessionNote"]["trace_id"] is not None
             assert evs["user.SessionNote"]["span_id"] is not None
+
+    async def test_span_records_have_status_code(self):
+        """Span JSONL records must include status_code field for OTel tool compatibility."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            m = TelemetryManager(session_id="sc-test", checkpoint_path=tmpdir)
+            await m.start()
+            m.emit(
+                make_event(TaskCreated, session_id="sc-test", backend="concurrent", task_id="t1")
+            )
+            m.emit(
+                make_event(
+                    TaskCompleted,
+                    session_id="sc-test",
+                    backend="concurrent",
+                    task_id="t1",
+                    duration_seconds=0.1,
+                )
+            )
+            m.emit(
+                make_event(TaskCreated, session_id="sc-test", backend="concurrent", task_id="t2")
+            )
+            m.emit(
+                make_event(
+                    TaskFailed,
+                    session_id="sc-test",
+                    backend="concurrent",
+                    task_id="t2",
+                    duration_seconds=0.1,
+                    error_type="RuntimeError",
+                )
+            )
+            await asyncio.sleep(0.1)
+            await m.stop()
+
+            filepath = os.path.join(tmpdir, os.listdir(tmpdir)[0])
+            rows = [json.loads(l) for l in open(filepath)]
+            spans = {
+                r["attributes"]["task_id"]: r
+                for r in rows
+                if r.get("section") == "span" and r.get("name") == "task"
+            }
+
+            assert spans["t1"]["status_code"] == "OK"
+            assert spans["t2"]["status_code"] == "ERROR"
+            assert spans["t2"]["status_description"] == "RuntimeError"
 
 
 class TestTaskStateTransitions:


### PR DESCRIPTION
This PR expands and improves the existing telemetry core as follows:

### Performance
- Replace per-event `asyncio.wait_for(queue.get(), timeout=0.05)` with a
  batch-drain dispatch loop: drain up to 500 events per iteration with
  `get_nowait()` (zero asyncio overhead), flush batch with a single
  `file.write()` call, yield only when the batch is full. Checkpoint file
  switched from line-buffered (1 syscall/event) to 128 KB block-buffered
  (1 syscall/batch). Result: **71% reduction in telemetry overhead at 40K
  tasks** (+7s → +2s vs. no-telemetry baseline).

- `_write_batch()` uses `dataclasses.fields() + getattr` instead of
  `dataclasses.asdict()` — avoids deep recursive copy and correctly captures
  `init=False` class-level fields on frozen dataclass subclasses.


# Without this PR — RHAPSODY ONLY (1 Node, 32 Cores)

| Workload | Telemetry | Create Tasks (s) | Submit (s) | Execute + Monitor (s) |
|----------|------------|------------------|-------------|------------------------|
| 40K      | Yes        | 0.29122          | 9.69184     | 39.87365               |
| 40K      | No         | 0.34087          | 2.64883     | 40.22597               |

# With this PR — RHAPSODY ONLY (1 Node, 32 Cores)

| Workload | Telemetry | Create Tasks (s) | Submit (s) | Execute + Monitor (s) |
|----------|------------|------------------|-------------|------------------------|
| 10K      | No         | 0.09899          | 0.60727     | 11.58421               |
| 10K      | Yes        | 0.07241          | 1.20898     | 10.68457               |
| 20K      | No         | 0.16736          | 1.45851     | 21.49847               |
| 20K      | Yes        | 0.13983          | 2.32631     | 20.68467               |
| 40K      | No         | 0.33841          | 2.73586     | 41.20632               |
| 40K      | Yes        | 0.30248          | 4.73076     | 41.82889               |

### Fixed
- Task span opened at `TaskCreated` (not `TaskSubmitted`), making all
  lifecycle events carry both `trace_id` and `span_id` — 100% OTel-aligned
  from the first event.
- Same-batch span ordering hazard: when `TaskCreated` and `TaskCompleted`
  land in the same 500-event batch, `_completed_span_ctx` preserves the
  closed span context so intermediate events can still be correlated.
  Applied to both task spans and the session span.
- `ResourceUpdate` events now carry session span `trace_id`/`span_id`
  (previously `None`).
- Sentinel-based shutdown: `stop()` awaits `queue.join()` (5 s timeout)
  then pushes `_STOP_SENTINEL` to unblock the loop cleanly; `emit()` is a
  no-op after `stop()`.
- Memory leak in `ConcurrentExecutionBackend._run_executable`: file handles
  for `capture_stdio` tasks were not closed on exception paths.

### Added
- `SpanBuffer` (public) — O(1) thread-safe span store replacing
  `InMemorySpanExporter`. `shutdown()` is a no-op so spans survive
  `tracer_provider.shutdown()`.
- Provider-agnostic OTel injection: `span_processors`, `metric_readers`,
  `resource` params on `TelemetryManager` and `Session.start_telemetry()`.
  Removes all env-var OTLP hacks and global provider mutation.
- `annotate_current_span()`, `register_span_enricher()`, `export_as_otlp()`.
- External trace/span injection for cross-component trace stitching.

## Test plan
- [x] All 86 existing telemetry unit tests pass
- [x] 40K task session: telemetry overhead ≤ 2s vs. no-telemetry baseline
- [x] JSONL: every task event has non-null `trace_id` and `span_id`
- [x] Same-batch scenario: `TaskCreated` + `TaskCompleted` in one batch → both
      events have correct `span_id`
- [x] `span_processors=[SimpleSpanProcessor(InMemorySpanExporter())]` reaches
      external exporter AND internal SpanBuffer
- [x] `stop()` drains all queued events within 5 s timeout