### PR TITLE
Support Dragon 0.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev,dask,radical_pilot]"
-          # As of now Dragon only available in >= py3.10 and < 3.13. So
-          # Install dragon if available for this Python version (fails gracefully if not)
+          # Dragon 0.14.0 supports Python 3.10–3.13. Fails gracefully on 3.9.
           pip install dragonhpc || echo "Dragon not available for Python ${{ matrix.python-version }}, skipping"
 
       - name: Run tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,75 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Dragon 0.14.0 full migration** — `DragonExecutionBackendV3` is fully ported
+  to the DragonHPC 0.14.0 API. Key changes:
+  - **Sharded DDict** — task results are now read from the correct DDict shard
+    using `results_ddict.manager(shard_idx)[tuid]`, matching how Dragon 0.14.0
+    writes results per `manager_idx`. The previous unsharded access caused the
+    monitor loop to block indefinitely.
+  - **Real task cancellation** — `cancel_task()` now calls Dragon's
+    `batch_task.cancel()` instead of a soft/fake cancel. Cancelled tasks are
+    eagerly removed from both `_task_registry` and `_monitored_batches`,
+    preventing the monitor thread from stalling on DDict polls for tasks that
+    will never deliver results.
+  - **Stdout capture restored** — Dragon 0.14.0 removed the unconditional
+    `stdout=Popen.PIPE` that Dragon 0.13.2 applied automatically. RHAPSODY now
+    explicitly injects it across all five `ProcessTemplate` construction paths so
+    stdout is captured for every process and executable task by default. Users can
+    override it via `process_template`.
+  - **Python 3.13 support** — Dragon 0.14.0 extends support to Python 3.13; the
+    CI matrix and `pyproject.toml` extras comment are updated accordingly.
+
+- **HPC integration test suite** (`tests/integration/test-hpc/dragon/`) — 25
+  end-to-end tests across five categories: multi-node GPU execution, single-node
+  GPU, task pinning and affinity, scale/stress (10 K+ tasks), and MPI
+  (mpi4py gather/allreduce/broadcast). Topology is detected dynamically from
+  `dragon.native.machine.System`; tests auto-skip when the required resources
+  are absent. The entire suite is excluded from CI via a `pytest_ignore_collect`
+  hook and only runs on a live cluster with `RHAPSODY_HPC=1`.
+
+- **HPC machine guides** — new setup guides for PSC Bridges-2 (SSH-based Dragon
+  launcher with TCP transport) and Purdue Anvil (Cray PE stack, identical to
+  Delta). The HPC machines index now clarifies that `ConcurrentExecutionBackend`
+  works out of the box on every machine, while `DragonExecutionBackendV3`
+  requires machine-specific configuration documented per page.
+
+- **Team and contributor documentation** — `docs/project/team.md` and
+  `README.md` updated to credit both the RADICAL Research Group (Rutgers) and
+  the HPE team.
+
+### Changed
+
+- **`TaskStateManager.update_task`** — removed per-call `asyncio.get_running_loop()`
+  / `try-except RuntimeError` on-loop detection. All backends already call this
+  from the event loop; the check was firing 128 K+ times per 64 K-task workload
+  and always taking the inline branch. The method now calls the implementation
+  directly. Unused `asyncio.Lock` also removed.
+
+- **`_build_process_template_kwargs` helper** — ProcessTemplate construction
+  across all five task priorities is consolidated into a single helper, adopted
+  from the `ashao/dragon-executor-hanging-bugfix` branch and adapted for
+  RHAPSODY's `stdout_pipe` semantics. Co-Authored-By: Andrew Shao (HPE).
+
+### Fixed
+
+- **Monitor loop race condition** — the two-step `if tuid not in dict` / `dict[tuid]`
+  access in `_monitor_loop` was a TOCTOU race with `cancel_task` running on the
+  event loop. Replaced with a single atomic `dict.get(tuid)` call.
+
+- **Python 3.13 `asyncio.get_event_loop()` error** — the `backend_v3` test
+  fixture called `asyncio.get_event_loop()` in a sync context. Python 3.13
+  tightened this from a `DeprecationWarning` to a hard `RuntimeError`. Fixed
+  by using `asyncio.new_event_loop()` instead.
+
+- **`long_running` task fixture unresponsive to cancellation** — the integration
+  test helper used `time.sleep(60)`, which ignores Dragon's `kill_by_exception`
+  mechanism until the sleep finishes (up to 60 seconds). Changed to a
+  `while True: time.sleep(0.1)` loop so the Dragon worker is freed within
+  ~100 ms of cancellation.
+
 ## [0.3.1] - 2026-05-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -106,7 +106,12 @@ RHAPSODY is licensed under the [MIT License](LICENSE.md).
 
 ## Acknowledgments
 
-RHAPSODY is developed by the [RADICAL Research Group](http://radical.rutgers.edu/) at Rutgers University.
+RHAPSODY is a collaborative project between two teams:
+
+- **[RADICAL Research Group](https://radical.rutgers.edu/)** — Rutgers University, New Jersey: core architecture, API design, session management, telemetry, and backend abstraction.
+- **[Hewlett Packard Enterprise (HPE)](https://www.hpe.com/)** — USA / Canada: DragonHPC runtime integration and Dragon backend development.
+
+See the full [Team](https://radical-cybertools.github.io/rhapsody/project/team/) page for details.
 
 ### Related Projects
 
@@ -123,7 +128,7 @@ If you use RHAPSODY in your research, please cite:
 ```bibtex
 @software{rhapsody2024,
   title={RHAPSODY: Runtime for Heterogeneous Applications, Service Orchestration and Dynamism},
-  author={RADICAL Research Team},
+  author={RADICAL Research Group, Rutgers University and Hewlett Packard Enterprise},
   year={2024},
   url={https://github.com/radical-cybertools/rhapsody},
   version={0.1.0}

--- a/_typos.toml
+++ b/_typos.toml
@@ -13,7 +13,7 @@ extend-ignore-identifiers-re = [
 [default.extend-words]
 # Add specific words that should not be corrected
 # rhapsody = "rhapsody"
-# HPE = "HPE"
+HPE = "HPE"
 
 [files]
 extend-exclude = [

--- a/docs/getting-started/resource-specification.md
+++ b/docs/getting-started/resource-specification.md
@@ -146,6 +146,26 @@ and placement settings flow through Dragon's [ProcessTemplate](https://dragonhpc
 There is **no backend-level `working_directory`** in V3. Every process
 configuration must be set per-task via `task_backend_specific_kwargs`.
 
+### Backend-level configuration (`batch_kwargs`)
+
+Pass a `batch_kwargs` dict when constructing the backend to tune the underlying
+`dragon.workflows.batch.Batch` instance:
+
+```python
+backend = await DragonExecutionBackendV3(batch_kwargs={
+    "num_nodes": 8,
+    "results_ddict_mem": 4 * 1024**3,  # 4 GiB results DDict
+    "scheduler_workers": 16,
+})
+```
+
+All accepted keys and their defaults are documented in the
+[Dragon Batch API](https://dragonhpc.github.io/dragon/doc/_build/html/ref/workflows/dragon.workflows.batch.Batch.html#dragon.workflows.batch.Batch).
+
+!!! note "Dragon 0.14.0"
+    `pool_nodes` is accepted for backwards compatibility but has no effect in
+    Dragon 0.14.0 — it is silently forced to `1` internally.
+
 **Supported `task_backend_specific_kwargs`:**
 
 | Key | Type | Description |
@@ -164,10 +184,15 @@ configuration must be set per-task via `task_backend_specific_kwargs`.
 | `policy` | `Policy` | Placement and GPU/NUMA affinity |
 | `options` | `ProcessOptions` | Dragon process options |
 
-!!! warning "Excluded parameters"
+!!! warning "Managed parameters"
     `target`, `args`, and `kwargs` are managed by RHAPSODY internally via
     `ComputeTask.executable`, `ComputeTask.arguments`, and `ComputeTask.function`.
     Do not set them inside `process_template`.
+
+    `stdout` defaults to `Popen.PIPE` for all process tasks (Dragon 0.14.0
+    requires this to be set explicitly for output capture). You can override
+    it by passing `stdout=None` in your template if you want to suppress
+    capture, or `stdout=Popen.STDOUT` to merge with stderr.
 
 ### Single-process task
 

--- a/docs/hpc-machines/anvil.md
+++ b/docs/hpc-machines/anvil.md
@@ -1,0 +1,151 @@
+# Purdue Anvil
+
+[Anvil](https://www.rcac.purdue.edu/compute/anvil) is an NSF-funded supercomputer at Purdue University, available through the ACCESS program. It features a Cray PE software stack with Cray MPICH as the system MPI library, making the setup nearly identical to NCSA Delta.
+
+## Environment Setup
+
+### 1. Allocate compute nodes
+
+```bash
+salloc --nodes=2 --exclusive --account=<your_account> --partition=cpu --tasks-per-node=32
+```
+
+### 2. Create a virtual environment using the system Python
+
+Anvil provides a system Python through the Cray PE. Use it with `--system-site-packages` so that Cray-optimized libraries (libfabric, PMIx, `mpi4py`, etc.) are inherited inside the venv — no need to rebuild `mpi4py` manually:
+
+```bash
+/opt/cray/pe/python/3.11.7/bin/python3 -m venv --system-site-packages rhapsody_env
+```
+
+!!! note
+    Any Python version available under `/opt/cray/pe/python/` can be used. Replace `3.11.7` with the version installed on your allocation.
+
+### 3. Load the Cray MPICH ABI module
+
+```bash
+module load cray-mpich-abi
+```
+
+!!! note
+    `cray-mpich-abi` provides the ABI-compatible MPI libraries required at runtime. Load it before activating the venv.
+
+### 4. Activate the environment
+
+```bash
+source rhapsody_env/bin/activate
+```
+
+### 5. Install RHAPSODY with Dragon backend
+
+```bash
+pip install "rhapsody-py[dragon]"
+```
+
+### 6. Configure Dragon for fast interconnect
+
+This step is required for Dragon to use Cray's high-speed libfabric instead of the default transport:
+
+```bash
+dragon-config add --ofi-runtime-lib=/opt/cray/libfabric/1.22.0/lib64
+```
+
+!!! warning
+    Skipping this step will result in Dragon falling back to a slower transport and significantly reduced multi-node performance. Always run it once after creating a new environment.
+
+### Run
+
+```bash
+dragon <script.py>
+```
+
+---
+
+## Example
+
+This example runs 32 MPI jobs concurrently using RHAPSODY's `Session` API with `DragonExecutionBackendV3`. Each job gets a random number of ranks (between 2 and 32), all scheduled across the 2 allocated nodes. Worker count is determined automatically by Dragon from the allocation.
+
+```python title="rhapsody-mpi.py"
+import asyncio
+import logging
+import random
+import time
+
+import rhapsody
+from rhapsody.api import ComputeTask, Session
+from rhapsody.backends import DragonExecutionBackendV3
+
+rhapsody.enable_logging(level=logging.DEBUG)
+
+
+def mpi_f(i, secs):
+    import mpi4py
+    mpi4py.rc.initialize = False
+
+    from mpi4py import MPI
+
+    MPI.Init()
+
+    time.sleep(secs)
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    size = comm.Get_size()
+    if rank == (size - 1):
+        print(f"Job {i}: Rank {rank} of {size} says: Hello from MPI!", flush=True)
+
+
+async def main():
+    njobs = 32
+    sleepsecs = 2
+    maxranks = 32
+
+    backend = await DragonExecutionBackendV3()
+    session = Session(backends=[backend])
+
+    print("--- Submitting Tasks ---")
+
+    tasks = []
+    for i in range(njobs):
+        nranks = random.randint(2, maxranks)
+        tasks.append(ComputeTask(
+            function=mpi_f,
+            args=[i, sleepsecs],
+            task_backend_specific_kwargs={'process_templates': [(nranks, {})]}
+        ))
+
+    async with session:
+        futures = await session.submit_tasks(tasks)
+        print(f"Submitted {len(tasks)} tasks. Received {len(futures)} futures.")
+
+        await asyncio.gather(*futures)
+
+        for t in tasks:
+            print(f"Task {t.uid}: {t.state} (output: {t.stdout.strip() if t.stdout else 'N/A'})")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Run with:
+
+```bash
+dragon rhapsody-mpi.py
+```
+
+---
+
+## Contributors
+
+<div class="grid cards" markdown>
+
+-   :fontawesome-solid-user-tie: **Aymen Alsaadi**
+
+    ---
+
+    RADICAL Lab, Rutgers University
+
+    [:fontawesome-solid-arrow-up-right-from-square: Profile](https://radical.rutgers.edu/people/aymen-alsaadi)
+
+</div>

--- a/docs/hpc-machines/bridges2.md
+++ b/docs/hpc-machines/bridges2.md
@@ -1,0 +1,169 @@
+# PSC Bridges-2
+
+[Bridges-2](https://www.psc.edu/resources/bridges-2/) is an NSF-funded supercomputer at the Pittsburgh Supercomputing Center (PSC). It features GPU and CPU partitions with NVIDIA V100 and A100 GPUs. Unlike Cray-based systems, Bridges-2 runs a standard SLURM scheduler without Cray PE, and Dragon's native SLURM launcher is **not** supported. Instead, Dragon must be launched using the SSH-based network launcher backed by a SLURM-generated host file.
+
+## Environment Setup
+
+### 1. Allocate compute nodes
+
+```bash
+salloc --nodes=2 --ntasks-per-node=28 --partition=RM --time=01:00:00 --account=<your_account>
+```
+
+For GPU nodes use the `GPU` partition:
+
+```bash
+salloc --nodes=2 --ntasks-per-node=8 --gpus-per-node=8 --partition=GPU --time=01:00:00 --account=<your_account>
+```
+
+### 2. Create a virtual environment
+
+Bridges-2 provides system Python via modules. Load it first:
+
+```bash
+module load python/3.11.5
+python3 -m venv ~/ve/rhapsody
+source ~/ve/rhapsody/bin/activate
+```
+
+### 3. Install RHAPSODY with Dragon backend
+
+```bash
+pip install "rhapsody-py[dragon]"
+```
+
+### 4. Generate the Dragon network configuration from SLURM
+
+Because Dragon's native SLURM launcher is not supported on Bridges-2, generate
+a network configuration YAML from the SLURM-assigned node list instead. Run
+this **inside your active SLURM allocation**:
+
+```bash
+dragon-network-config --output-to-yaml
+```
+
+This reads `$SLURM_NODELIST` and writes a `slurm.yaml` file in the current
+directory describing the network topology Dragon will use.
+
+!!! note
+    `dragon-network-config` must be run inside a SLURM allocation (after `salloc`
+    or inside an `sbatch` script) so that `$SLURM_NODELIST` is populated. Running
+    it on the login node produces an empty or single-node configuration.
+
+!!! warning
+    Re-run `dragon-network-config --output-to-yaml` each time you request a new
+    allocation — SLURM assigns a different set of nodes and the previous
+    `slurm.yaml` will reference stale hostnames.
+
+### 5. Run with the SSH-based launcher
+
+Use the `--network-config` flag to pass the generated YAML and `-t tcp` to
+select the TCP transport (required on Bridges-2 since Cray libfabric is not
+available):
+
+```bash
+dragon -w ssh --network-config slurm.yaml -t tcp <script.py>
+```
+
+---
+
+## Run
+
+Full launch sequence from inside a SLURM allocation:
+
+```bash
+# Step 1 — generate network config from the current allocation
+dragon-network-config --output-to-yaml
+
+# Step 2 — run your RHAPSODY script
+dragon -w ssh --network-config slurm.yaml -t tcp 01-workload-async-gather.py
+```
+
+---
+
+## Example
+
+This example submits a heterogeneous workload mixing function tasks and
+executable tasks using RHAPSODY's `Session` API with `DragonExecutionBackendV3`.
+
+```python title="01-workload-async-gather.py"
+import asyncio
+import logging
+
+import rhapsody
+from rhapsody.api import ComputeTask, Session
+from rhapsody.backends import DragonExecutionBackendV3
+
+rhapsody.enable_logging(level=logging.DEBUG)
+
+
+def compute(x: int) -> int:
+    return x * x
+
+
+async def main():
+    backend = await DragonExecutionBackendV3()
+    session = Session(backends=[backend])
+
+    tasks = [ComputeTask(function=compute, args=(i,)) for i in range(16)]
+
+    async with session:
+        futures = await session.submit_tasks(tasks)
+        print(f"Submitted {len(tasks)} tasks. Received {len(futures)} futures.")
+
+        await asyncio.gather(*futures)
+
+        for t in tasks:
+            print(f"{t.uid}: state={t.state}  return_value={t.return_value}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+Launch:
+
+```bash
+dragon-network-config --output-to-yaml
+dragon -w ssh --network-config slurm.yaml -t tcp 01-workload-async-gather.py
+```
+
+---
+
+## Notes
+
+### Why SSH launcher instead of SLURM launcher
+
+Dragon supports two multi-node launchers: `slurm` (native SLURM integration,
+used on Delta and Perlmutter) and `ssh` (SSH-based, generic). Bridges-2 does
+not expose the PMI/PMIx hooks that Dragon's SLURM launcher depends on, so
+`-w ssh` is required. The `--network-config` flag bridges the gap by giving
+Dragon the node list that it would otherwise obtain from the scheduler.
+
+### TCP transport (`-t tcp`)
+
+Bridges-2 does not have Cray libfabric or a compatible OFI provider. Use
+`-t tcp` to select Dragon's TCP transport. Performance will be lower than on
+Cray libfabric systems (Delta, Perlmutter), but correctness is unaffected.
+
+### Re-using `slurm.yaml` across runs
+
+`slurm.yaml` is tied to the node names in a specific SLURM allocation. It is
+safe to run multiple scripts in the same session without regenerating it, but
+it must be regenerated whenever a new `salloc` or `sbatch` is issued.
+
+---
+
+## Contributors
+
+<div class="grid cards" markdown>
+
+-   :fontawesome-solid-user-tie: **Aymen Alsaadi**
+
+    ---
+
+    RADICAL Lab, Rutgers University
+
+    [:fontawesome-solid-arrow-up-right-from-square: Profile](https://radical.rutgers.edu/people/aymen-alsaadi)
+
+</div>

--- a/docs/hpc-machines/index.md
+++ b/docs/hpc-machines/index.md
@@ -1,15 +1,22 @@
 # RHAPSODY on NSF and DOE Machines
 
-This section provides machine-specific setup guides and verified examples for running RHAPSODY on NSF and DOE leadership computing facilities. These machines are periodically tested and verified
-against RHAPSODY and it pre-release changes.
+This section provides machine-specific setup guides and verified examples for running RHAPSODY on NSF and DOE leadership computing facilities. These machines are periodically tested and verified against RHAPSODY and its pre-release changes.
 
-Each guide covers environment setup, module loading, job allocation, and working examples — with different examples.
+## Backend compatibility
+
+**`ConcurrentExecutionBackend (designed for debug and tests single node only)`** works out of the box on every machine listed here — no machine-specific configuration is required. Install RHAPSODY and run.
+
+**`DragonExecutionBackendV3 (designed for large scale multi-node)`** requires machine-specific setup: each HPC system has its own software stack, MPI library, interconnect, and job launcher. The exact steps — module loading, virtual environment creation, transport configuration, and launch command — differ per machine and are documented in each section below.
+
+Each guide covers environment setup, module loading, job allocation, and working examples.
 
 ## Supported Machines
 
-| Machine | Facility | Stack | Backend | Status |
-|---------|----------|-------|---------|--------|
-| [NCSA Delta](ncsa-delta.md) | NSF / NCSA | Cray MPICH (PMIx) | `DragonExecutionBackendV3` | Verified |
-| [NERSC Perlmutter](perlmutter.md) | DOE / NERSC | Cray libfabric + CUDA | `DragonVllmInferenceBackend` | Verified |
+| Machine | Facility | Stack | Status |
+|---------|----------|-------|--------|
+| [NCSA Delta](ncsa-delta.md) | NSF / NCSA | Cray MPICH (PMIx) | Verified |
+| [NERSC Perlmutter](perlmutter.md) | DOE / NERSC | Cray libfabric + CUDA | Verified |
+| [PSC Bridges-2](bridges2.md) | NSF / PSC | Standard SLURM, TCP | Verified |
+| [Purdue Anvil](anvil.md) | NSF / ACCESS / Purdue | Cray MPICH (PMIx) | Verified |
 
 More machines will be added as they are tested and validated.

--- a/docs/project/team.md
+++ b/docs/project/team.md
@@ -1,29 +1,47 @@
 # Team
 
-Meet the researchers and developers behind RHAPSODY.
+RHAPSODY is a collaborative project between the
+[RADICAL Research Group](https://radical.rutgers.edu/) at Rutgers University
+and [Hewlett Packard Enterprise (HPE)](https://www.hpe.com/).
 
-## RADICAL Research Team
+---
 
-RHAPSODY is developed by the RADICAL Research Team at Rutgers University.
+## RADICAL Research Group — Rutgers University, New Jersey
 
-### Core Development Team
+The RADICAL group at Rutgers leads the core architecture, API design, session
+management, telemetry, and backend abstraction layer of RHAPSODY.
 
-- Research scientists and engineers from the RADICAL group
-- Graduate students and postdocs
-- Collaborators from partner institutions
+- **Institution**: Rutgers, The State University of New Jersey
+- **Lab**: RADICAL (Rutgers Discovery Informatics Institute)
+- **Website**: [https://radical.rutgers.edu/](https://radical.rutgers.edu/)
+- **GitHub**: [radical-cybertools](https://github.com/radical-cybertools)
 
-## Collaborators
+---
 
-RHAPSODY benefits from collaboration with:
+## Hewlett Packard Enterprise (HPE) — USA / Canada
 
-- National laboratories
-- Academic research institutions
-- Industry partners
-- Open source community contributors
+The HPE team contributes DragonHPC runtime integration, Dragon backend
+development, and HPC system expertise. HPE develops and maintains the
+[Dragon](https://dragonhpc.org/portal/index.html) distributed runtime system.
+
+- **Institution**: Hewlett Packard Enterprise
+- **Website**: [https://www.hpe.com/](https://www.hpe.com/)
+
+### Contributors
+
+| Name | Organization | Location | Role |
+|------|-------------|----------|------|
+| Kent Lee | Hewlett Packard Enterprise | USA | HPC Software Architect and Engineer |
+| Nick Radcliffe | Hewlett Packard Enterprise | USA | Software Engineer |
+| Pete Mendygral | Hewlett Packard Enterprise | USA | Senior Distinguished Technologist - AI Software Architect  |
+| Andrew Shao | Hewlett Packard Enterprise Canada | Canada | HPC & AI Research Scientist and Developer |
+
+---
 
 ## Contact
 
-- **Website**: [https://radical.rutgers.edu/](https://radical.rutgers.edu/)
-- **GitHub**: [https://github.com/radical-cybertools/rhapsody](https://github.com/radical-cybertools/rhapsody)
+- **General**: [info@radical.org](mailto:info@radical.org)
+- **GitHub Issues**: [https://github.com/radical-cybertools/rhapsody/issues](https://github.com/radical-cybertools/rhapsody/issues)
+- **RADICAL Lab**: [https://radical.rutgers.edu/](https://radical.rutgers.edu/)
 
-For more information about the project, see the [NSF Award](nsf-award.md) details.
+For funding and award information, see the [NSF Award](nsf-award.md) page.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,8 @@ nav:
       - Overview: hpc-machines/index.md
       - NCSA Delta: hpc-machines/ncsa-delta.md
       - NERSC Perlmutter: hpc-machines/perlmutter.md
+      - PSC Bridges-2: hpc-machines/bridges2.md
+      - Purdue Anvil: hpc-machines/anvil.md
   - Project:
       - project/index.md
       - Roadmap: project/roadmap.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ telemetry = ["opentelemetry-sdk>=1.20.0", "nvidia-ml-py"]
 # Backend-specific dependencies
 dask = ["dask[distributed]>=2023.0.0"]
 radical_pilot = ["radical.pilot>=1.30.0"]
-dragon = ["dragonhpc==0.14.0"]  # Requires Python >= 3.10
+dragon = ["dragonhpc==0.14.0"]  # Requires Python >= 3.10, supports up to 3.13
 vllm-dragon = [
     "aiohttp>=3.8.0",
     "pyyaml>=6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ telemetry = ["opentelemetry-sdk>=1.20.0", "nvidia-ml-py"]
 # Backend-specific dependencies
 dask = ["dask[distributed]>=2023.0.0"]
 radical_pilot = ["radical.pilot>=1.30.0"]
-dragon = ["dragonhpc==0.13.2"]  # Requires Python >= 3.10
+dragon = ["dragonhpc==0.14.0"]  # Requires Python >= 3.10
 vllm-dragon = [
     "aiohttp>=3.8.0",
     "pyyaml>=6.0",

--- a/src/rhapsody/api/session.py
+++ b/src/rhapsody/api/session.py
@@ -28,30 +28,19 @@ class TaskStateManager:
     def __init__(self):
         self._task_futures: dict[str, asyncio.Future] = {}
         self._terminal_states = set()  # Will be populated by backends
-        self._lock = asyncio.Lock()
         self._loop: asyncio.AbstractEventLoop | None = None
         # Telemetry observer — set by Session.enable_telemetry(), None = zero cost
         self._telemetry_observer: Callable[[dict, str], None] | None = None
 
     def bind_loop(self, loop: asyncio.AbstractEventLoop) -> None:
-        """Bind an event loop to the manager for thread-safe updates."""
         self._loop = loop
 
     def update_task(self, task: dict | BaseTask, state: str, **kwargs: object) -> None:
-        """Update task state and notify waiters (thread-safe)."""
-        if self._loop and not self._loop.is_closed():
-            self._loop.call_soon_threadsafe(self._update_task_impl, task, state)
-        else:
-            # Fallback if no loop bound (e.g. synch tests) or loop closed
-            # Warning: This is not thread-safe if called from another thread
-            logger.error(
-                "update_task called without a valid event loop "
-                f"(loop={self._loop}, closed={getattr(self._loop, 'is_closed', lambda: None)()})"
-            )
-            self._update_task_impl(task, state)
+        """Update task state and notify waiters. Must be called from the event loop.
 
-    def _update_task_impl(self, task: dict | BaseTask, state: str) -> None:
-        """Actual update logic, expected to run on the event loop."""
+        Backends delivering results from a background thread must cross the thread boundary first
+        via loop.call_soon_threadsafe(self.update_task, task, state).
+        """
         uid = task["uid"]
 
         # Update the task object in-place (Single Source of Truth)

--- a/src/rhapsody/backends/execution/dragon.py
+++ b/src/rhapsody/backends/execution/dragon.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import os
-import shlex
 import sys
 import threading
 import time
@@ -3346,32 +3345,39 @@ class DragonExecutionBackendV3(BaseBackend):
             def target(*a, **kw):
                 return asyncio.run(original_target(*a, **kw))
 
+        capture_stdio = bool(task.get("capture_stdio")) and not is_function
+
         # Get template configs once
         process_templates_config = backend_kwargs.get("process_templates")
         process_template_config = backend_kwargs.get("process_template")
 
-        # Dragon's batch PIPE hangs when stderr is captured for subprocess tasks.
-        # Fix: write a shell script that redirects its own stdout/stderr to files,
-        # then invoke it as `bash script.sh`.  Dragon's forced stdout PIPE sees an
-        # empty stream → immediate EOF → no hang.  Files are written by the script.
-        redirect = task.get("capture_stdio") and not is_function
-        stdout_path = stderr_path = script_path = None
-        if redirect:
-            stdout_path = os.path.join(self._work_dir, f"{uid}.stdout")
-            stderr_path = os.path.join(self._work_dir, f"{uid}.stderr")
-            script_path = os.path.join(self._work_dir, f"{uid}.sh")
-            cmd_line = " ".join(
-                [shlex.quote(str(target))] + [shlex.quote(str(a)) for a in task_args]
-            )
-            with open(script_path, "w") as _f:
-                _f.write(
-                    f"#!/usr/bin/bash\n"
-                    f"{cmd_line}"
-                    f" 1>{shlex.quote(stdout_path)}"
-                    f" 2>{shlex.quote(stderr_path)}\n"
-                )
-            target = "/bin/bash"
-            task_args = (script_path,)
+        _format_process_template_kwargs = lambda template_cfg: {**template_cfg, "args": task_args, "kwargs": task_kwargs}
+        def _process_capture_stdio(template_kwargs: dict[str, Any], capture_stdio: bool) -> dict[str, Any]:
+            """
+            Define default arguments for stdout and stderr capture
+
+            By default, bind the process STDOUT and STDERR to the streams on the
+            main RHAPSODY process
+            """
+            if capture_stdio:
+                template_kwargs.setdefault("stdout", Popen.PIPE)
+                template_kwargs.setdefault("stderr", Popen.PIPE)
+            return template_kwargs
+
+        def _build_process_template_kwargs(template_cfg: dict[str, Any], capture_stdio: bool) -> dict[str, Any]:
+            """
+            Build the kwargs for the process template
+
+            1) reformats the user-defined args and kwargs for the task template
+            2) defines the STDOUT/STDERR streams if RHAPSODY should capture output
+            """
+            template_kwargs = _format_process_template_kwargs(template_cfg)
+            template_kwargs = _process_capture_stdio(template_kwargs, capture_stdio)
+            return template_kwargs
+
+        # stdout_path = None # @AymenFJA, Confirm that these can be removed?
+        # stderr_path = None # @AymenFJA, Confirm that these can be removed?
+        # script_path = None # @AymenFJA, Confirm that these can be removed?
 
         # Single decision tree - no redundant checks
         if process_templates_config is not None:
@@ -3379,7 +3385,7 @@ class DragonExecutionBackendV3(BaseBackend):
             process_templates = [
                 (
                     nranks,
-                    ProcessTemplate(target, **{**tc, "args": task_args, "kwargs": task_kwargs}),
+                    ProcessTemplate(target, **_build_process_template_kwargs(tc, capture_stdio)),
                 )
                 for nranks, tc in process_templates_config
             ]
@@ -3390,7 +3396,7 @@ class DragonExecutionBackendV3(BaseBackend):
             # Priority 2: Process with user template
             batch_task = self.batch.process(
                 ProcessTemplate(
-                    target, **{**process_template_config, "args": task_args, "kwargs": task_kwargs}
+                    target, **_build_process_template_kwargs(process_template_config, capture_stdio)
                 ),
                 name=name,
                 timeout=timeout,
@@ -3399,11 +3405,15 @@ class DragonExecutionBackendV3(BaseBackend):
 
         elif backend_kwargs.get("type") == "mpi":
             # Priority 3: Job auto-build
+            auto_template_kwargs = _build_process_template_kwargs(
+                {"args": task_args, "kwargs": task_kwargs},
+                capture_stdio
+            )
             batch_task = self.batch.job(
                 [
                     (
                         backend_kwargs.get("ranks", 1),
-                        ProcessTemplate(target, args=task_args, kwargs=task_kwargs),
+                        ProcessTemplate(target, **auto_template_kwargs),
                     )
                 ],
                 name=name,
@@ -3420,8 +3430,12 @@ class DragonExecutionBackendV3(BaseBackend):
 
         else:
             # Priority 5: Executable process auto-build
+            auto_template_kwargs = _build_process_template_kwargs(
+                {"args": task_args, "kwargs": task_kwargs},
+                capture_stdio
+            )
             batch_task = self.batch.process(
-                ProcessTemplate(target, args=task_args, kwargs=task_kwargs),
+                ProcessTemplate(target, **auto_template_kwargs),
                 name=name,
                 timeout=timeout,
             )
@@ -3432,9 +3446,9 @@ class DragonExecutionBackendV3(BaseBackend):
             "uid": uid,
             "description": task,
             "batch_task": batch_task,
-            "stdout_path": stdout_path,
-            "stderr_path": stderr_path,
-            "script_path": script_path,
+#            "stdout_path": stdout_path, # @AymenFJA: Confirm that these can be removed?
+#            "stderr_path": stderr_path, # @AymenFJA: Confirm that these can be removed?
+#            "script_path": script_path, # @AymenFJA: Confirm that these can be removed?
         }
 
         self.logger.debug(f"Created {execution_mode} task: {uid}")

--- a/src/rhapsody/backends/execution/dragon.py
+++ b/src/rhapsody/backends/execution/dragon.py
@@ -24,8 +24,6 @@ try:
 
     import dragon
     from dragon.data.ddict.ddict import DDict
-    from dragon.infrastructure.gpu_desc import AccVendor
-    from dragon.infrastructure.gpu_desc import find_accelerators
     from dragon.infrastructure.policy import Policy
 
     # Node Telemetry only
@@ -37,7 +35,6 @@ try:
     from dragon.native.process_group import DragonUserCodeError
     from dragon.native.process_group import ProcessGroup
     from dragon.native.queue import Queue
-    from dragon.telemetry import Telemetry
     from dragon.workflows.batch import Batch
 
 except ImportError:  # pragma: no cover - environment without Dragon
@@ -52,9 +49,6 @@ except ImportError:  # pragma: no cover - environment without Dragon
     Policy = None
     Batch = None
     Event = None
-    Telemetry = None
-    AccVendor = None
-    find_accelerators = None
 
 
 def _get_logger() -> logging.Logger:
@@ -3079,8 +3073,8 @@ class DragonExecutionBackendV3(BaseBackend):
     """Dragon Batch backend using the streaming pipeline model.
 
     Tasks submitted via batch.function()/process()/job() are auto-dispatched by the Batch
-    background thread. A single monitor thread polls each task with Task.get(block=False)
-    and fires callbacks when results become available in the DDict.
+    background thread. A single monitor thread polls each task's manager-specific DDict shard
+    and fires callbacks when results become available.
 
     Note on working directory:
         DragonExecutionBackendV3 does not support a backend-level working directory.
@@ -3105,9 +3099,7 @@ class DragonExecutionBackendV3(BaseBackend):
 
     def __init__(
         self,
-        num_nodes: Optional[int] = None,
-        pool_nodes: Optional[int] = None,
-        disable_telemetry: bool = False,
+        batch_kwargs: Optional[dict] = None,
         name: Optional[str] = "dragon",
     ):
         if not Batch:
@@ -3116,11 +3108,7 @@ class DragonExecutionBackendV3(BaseBackend):
         super().__init__(name=name)
 
         self.logger = _get_logger()
-        self.batch = Batch(
-            num_nodes=num_nodes,
-            pool_nodes=pool_nodes,
-            disable_telem=disable_telemetry,
-        )
+        self.batch = Batch(**(batch_kwargs or {}))
 
         self._backend_state = BackendMainStates.INITIALIZED
         self._callback_func: Callable = lambda t, s: None
@@ -3195,12 +3183,25 @@ class DragonExecutionBackendV3(BaseBackend):
                 for tuid in batch_tuids:
                     if tuid not in self._monitored_batches:
                         continue
-                    # Single DDict read: KeyError means not ready yet (avoids redundant __contains__)
+                    batch_task, uid = self._monitored_batches[tuid]
+
+                    # Wait until the Batch client compiler has placed this task on a manager.
+                    # manager_idx is None in the window between submission and compile.
+                    manager_idx = batch_task.core.manager_idx
+                    if manager_idx is None:
+                        continue
+
+                    # SCHEDULER_MANAGER_IDX == -1 maps to shard 0; subnode managers map 1-to-1.
+                    ddict_shard_idx = 0 if manager_idx == -1 else manager_idx
+
                     try:
-                        result, tb, raised, stdout, stderr = self.batch.results_ddict[tuid]
+                        result, tb, raised, stdout, stderr = self.batch.results_ddict.manager(
+                            ddict_shard_idx
+                        )[tuid]
                     except KeyError:
                         continue
-                    batch_task, uid = self._monitored_batches.pop(tuid)
+
+                    self._monitored_batches.pop(tuid, None)
                     completed.append((uid, result, tb, raised, stdout, stderr))
 
                 # One cross-thread wakeup for the entire sweep batch
@@ -3350,11 +3351,20 @@ class DragonExecutionBackendV3(BaseBackend):
         process_templates_config = backend_kwargs.get("process_templates")
         process_template_config = backend_kwargs.get("process_template")
 
-        # Dragon's batch PIPE hangs when stderr is captured for subprocess tasks.
-        # Fix: write a shell script that redirects its own stdout/stderr to files,
-        # then invoke it as `bash script.sh`.  Dragon's forced stdout PIPE sees an
-        # empty stream → immediate EOF → no hang.  Files are written by the script.
+        # When capture_stdio is requested for subprocess tasks, write a shell script that
+        # redirects both stdout and stderr to files, then invoke it as `bash script.sh`.
+        # Dragon's PIPE for the bash wrapper sees an empty stream → immediate EOF → no hang.
         redirect = task.get("capture_stdio") and not is_function
+
+        # Dragon 0.13.2 unconditionally set template.stdout = Popen.PIPE for every
+        # process task, so stdout was always captured.  Dragon 0.14.0 removed that —
+        # needs_output is only True when the template explicitly carries stdout=Popen.PIPE.
+        # Restore that behavior for subprocess tasks:
+        #   • no capture_stdio redirect → stdout=Popen.PIPE (direct capture via DDict)
+        #   • capture_stdio redirect     → stdout=None      (bash script writes to file;
+        #                                                     PIPE would just see EOF)
+        # Functions capture stdout via io.StringIO internally; no PIPE needed.
+        stdout_pipe = None if (redirect or is_function) else Popen.PIPE
         stdout_path = stderr_path = script_path = None
         if redirect:
             stdout_path = os.path.join(self._work_dir, f"{uid}.stdout")
@@ -3376,10 +3386,14 @@ class DragonExecutionBackendV3(BaseBackend):
         # Single decision tree - no redundant checks
         if process_templates_config is not None:
             # Priority 1: Job with user templates
+            # stdout_pipe is the default; user's tc dict can override it.
             process_templates = [
                 (
                     nranks,
-                    ProcessTemplate(target, **{**tc, "args": task_args, "kwargs": task_kwargs}),
+                    ProcessTemplate(
+                        target,
+                        **{"stdout": stdout_pipe, **tc, "args": task_args, "kwargs": task_kwargs},
+                    ),
                 )
                 for nranks, tc in process_templates_config
             ]
@@ -3388,9 +3402,16 @@ class DragonExecutionBackendV3(BaseBackend):
 
         elif process_template_config is not None:
             # Priority 2: Process with user template
+            # stdout_pipe is the default; user's process_template_config can override it.
             batch_task = self.batch.process(
                 ProcessTemplate(
-                    target, **{**process_template_config, "args": task_args, "kwargs": task_kwargs}
+                    target,
+                    **{
+                        "stdout": stdout_pipe,
+                        **process_template_config,
+                        "args": task_args,
+                        "kwargs": task_kwargs,
+                    },
                 ),
                 name=name,
                 timeout=timeout,
@@ -3403,7 +3424,9 @@ class DragonExecutionBackendV3(BaseBackend):
                 [
                     (
                         backend_kwargs.get("ranks", 1),
-                        ProcessTemplate(target, args=task_args, kwargs=task_kwargs),
+                        ProcessTemplate(
+                            target, args=task_args, kwargs=task_kwargs, stdout=stdout_pipe
+                        ),
                     )
                 ],
                 name=name,
@@ -3421,7 +3444,7 @@ class DragonExecutionBackendV3(BaseBackend):
         else:
             # Priority 5: Executable process auto-build
             batch_task = self.batch.process(
-                ProcessTemplate(target, args=task_args, kwargs=task_kwargs),
+                ProcessTemplate(target, args=task_args, kwargs=task_kwargs, stdout=stdout_pipe),
                 name=name,
                 timeout=timeout,
             )
@@ -3465,14 +3488,28 @@ class DragonExecutionBackendV3(BaseBackend):
         if uid not in self._task_registry:
             raise ValueError(f"Task {uid} not found")
 
-        # NOTE: dragon.batch does not expose nor support
-        # process/function/job cancellation, we just notify
-        # the asyncflow that the task is cancelled so not to block the flow
-        task = self._task_registry[uid]["description"]
-        self._callback_func(task, "CANCELED")
-        self._cancelled_tasks.add(uid)
+        batch_task = self._task_registry[uid]["batch_task"]
+        loop = asyncio.get_running_loop()
 
-        return True
+        try:
+            cancelled = await loop.run_in_executor(None, batch_task.cancel)
+        except Exception as e:
+            self.logger.warning(f"Dragon cancel failed for {uid}: {e}; falling back to soft-cancel")
+            cancelled = True
+
+        if cancelled:
+            registry_entry = self._task_registry.pop(uid, None)
+            if registry_entry is None:
+                # Task completed naturally between the executor call and here — not cancelled.
+                return False
+            task_desc = registry_entry["description"]
+            # Stop the monitor loop from polling this task's DDict entry. Without this,
+            # the blocking DDict IPC for a cancelled task can stall the monitor thread
+            # and delay result delivery for subsequently submitted tasks.
+            self._monitored_batches.pop(batch_task.uid, None)
+            self._callback_func(task_desc, "CANCELED")
+
+        return cancelled
 
     async def shutdown(self) -> None:
         """Shutdown the backend and clean up resources."""
@@ -3498,10 +3535,11 @@ class DragonExecutionBackendV3(BaseBackend):
         # Close Batch
         if self.batch:
             try:
-                self.logger.debug("Closing batch...")
-                self.batch.close()
+                self.logger.debug("Joining batch...")
                 self.batch.join(timeout=10.0)
-                self.logger.debug("Batch closed successfully")
+                self.logger.debug("Destroying batch...")
+                self.batch.destroy(timeout=15.0)
+                self.logger.debug("Batch destroyed successfully")
             except Exception as e:
                 self.logger.warning(f"Error closing batch gracefully: {e}")
                 try:
@@ -3526,14 +3564,8 @@ class DragonExecutionBackendV3(BaseBackend):
     @classmethod
     async def create(
         cls,
-        num_nodes: Optional[int] = None,
-        pool_nodes: Optional[int] = None,
-        disable_telemetry: bool = False,
+        batch_kwargs: Optional[dict] = None,
     ):
         """Create and initialize a DragonExecutionBackendV3."""
-        backend = cls(
-            num_nodes=num_nodes,
-            pool_nodes=pool_nodes,
-            disable_telemetry=disable_telemetry,
-        )
+        backend = cls(batch_kwargs=batch_kwargs)
         return await backend

--- a/src/rhapsody/backends/execution/dragon.py
+++ b/src/rhapsody/backends/execution/dragon.py
@@ -3351,8 +3351,18 @@ class DragonExecutionBackendV3(BaseBackend):
         process_templates_config = backend_kwargs.get("process_templates")
         process_template_config = backend_kwargs.get("process_template")
 
-        _format_process_template_kwargs = lambda template_cfg: {**template_cfg, "args": task_args, "kwargs": task_kwargs}
-        def _process_capture_stdio(template_kwargs: dict[str, Any], capture_stdio: bool) -> dict[str, Any]:
+        def _format_process_template_kwargs(
+                template_cfg: dict[str, Any]
+            ) -> dict[str, Any]:
+            """
+            Repack task configuration into one dictionary
+            """
+            return {**template_cfg, "args": task_args, "kwargs": task_kwargs}
+
+        def _process_capture_stdio(
+                template_kwargs: dict[str, Any],
+                capture_stdio: bool
+            ) -> dict[str, Any]:
             """
             Define default arguments for stdout and stderr capture
 
@@ -3364,7 +3374,10 @@ class DragonExecutionBackendV3(BaseBackend):
                 template_kwargs.setdefault("stderr", Popen.PIPE)
             return template_kwargs
 
-        def _build_process_template_kwargs(template_cfg: dict[str, Any], capture_stdio: bool) -> dict[str, Any]:
+        def _build_process_template_kwargs(
+                template_cfg: dict[str, Any],
+                capture_stdio: bool
+            ) -> dict[str, Any]:
             """
             Build the kwargs for the process template
 
@@ -3385,7 +3398,9 @@ class DragonExecutionBackendV3(BaseBackend):
             process_templates = [
                 (
                     nranks,
-                    ProcessTemplate(target, **_build_process_template_kwargs(tc, capture_stdio)),
+                    ProcessTemplate(
+                        target,
+                        **_build_process_template_kwargs(tc, capture_stdio)),
                 )
                 for nranks, tc in process_templates_config
             ]
@@ -3396,7 +3411,10 @@ class DragonExecutionBackendV3(BaseBackend):
             # Priority 2: Process with user template
             batch_task = self.batch.process(
                 ProcessTemplate(
-                    target, **_build_process_template_kwargs(process_template_config, capture_stdio)
+                    target,
+                    **_build_process_template_kwargs(
+                        process_template_config, capture_stdio
+                    )
                 ),
                 name=name,
                 timeout=timeout,

--- a/src/rhapsody/backends/execution/dragon.py
+++ b/src/rhapsody/backends/execution/dragon.py
@@ -3076,10 +3076,27 @@ class DragonExecutionBackendV3(BaseBackend):
     background thread. A single monitor thread polls each task's manager-specific DDict shard
     and fires callbacks when results become available.
 
+    Args:
+        batch_kwargs: Forwarded verbatim to ``dragon.workflows.batch.Batch()``.
+
+            Supported keys (Dragon 0.14.0):
+
+            - ``num_nodes`` *(int, optional)* — nodes to use; defaults to the full
+              allocation.
+            - ``disable_telem`` *(bool)* — disable Dragon's internal telemetry
+              (default ``False``).
+            - ``scheduler_workers`` *(int, optional)* — size of the scheduler's local
+              worker pool; defaults to ``num_nodes``. Increase this when running many
+              concurrent multi-node (MPI) jobs.
+            - ``results_ddict_mem`` *(int, optional)* — bytes to allocate for the
+              results DDict (default: 1 GiB × num_nodes). Increase for workloads that
+              return large arrays or submit millions of tasks.
+            - ``pool_nodes`` — **no-op in Dragon 0.14.0**, kept for API compatibility.
+
     Note on working directory:
         DragonExecutionBackendV3 does not support a backend-level working directory.
-        To set the working directory per task, use ``task_backend_specific_kwargs``
-        with ``process_template`` (single process) or ``process_templates`` (MPI job)::
+        Set it per task via ``task_backend_specific_kwargs`` with ``process_template``
+        (single process) or ``process_templates`` (MPI job)::
 
             ComputeTask(
                 function=my_func,

--- a/src/rhapsody/backends/execution/dragon.py
+++ b/src/rhapsody/backends/execution/dragon.py
@@ -3198,9 +3198,10 @@ class DragonExecutionBackendV3(BaseBackend):
                 # Collect all completed tasks in this sweep, then deliver in one batch
                 completed = []
                 for tuid in batch_tuids:
-                    if tuid not in self._monitored_batches:
+                    entry = self._monitored_batches.get(tuid)
+                    if entry is None:
                         continue
-                    batch_task, uid = self._monitored_batches[tuid]
+                    batch_task, uid = entry
 
                     # Wait until the Batch client compiler has placed this task on a manager.
                     # manager_idx is None in the window between submission and compile.

--- a/src/rhapsody/backends/execution/dragon.py
+++ b/src/rhapsody/backends/execution/dragon.py
@@ -3351,6 +3351,29 @@ class DragonExecutionBackendV3(BaseBackend):
         process_templates_config = backend_kwargs.get("process_templates")
         process_template_config = backend_kwargs.get("process_template")
 
+        # Dragon's batch PIPE hangs when stderr is captured for subprocess tasks.
+        # Fix: write a shell script that redirects its own stdout/stderr to files,
+        # then invoke it as `bash script.sh`.  Dragon's forced stdout PIPE sees an
+        # empty stream → immediate EOF → no hang.  Files are written by the script.
+        redirect = task.get("capture_stdio") and not is_function
+        stdout_path = stderr_path = script_path = None
+        if redirect:
+            stdout_path = os.path.join(self._work_dir, f"{uid}.stdout")
+            stderr_path = os.path.join(self._work_dir, f"{uid}.stderr")
+            script_path = os.path.join(self._work_dir, f"{uid}.sh")
+            cmd_line = " ".join(
+                [shlex.quote(str(target))] + [shlex.quote(str(a)) for a in task_args]
+            )
+            with open(script_path, "w") as _f:
+                _f.write(
+                    f"#!/usr/bin/bash\n"
+                    f"{cmd_line}"
+                    f" 1>{shlex.quote(stdout_path)}"
+                    f" 2>{shlex.quote(stderr_path)}\n"
+                )
+            target = "/bin/bash"
+            task_args = (script_path,)
+
         def _format_process_template_kwargs(
                 template_cfg: dict[str, Any]
             ) -> dict[str, Any]:
@@ -3387,10 +3410,6 @@ class DragonExecutionBackendV3(BaseBackend):
             template_kwargs = _format_process_template_kwargs(template_cfg)
             template_kwargs = _process_capture_stdio(template_kwargs, capture_stdio)
             return template_kwargs
-
-        # stdout_path = None # @AymenFJA, Confirm that these can be removed?
-        # stderr_path = None # @AymenFJA, Confirm that these can be removed?
-        # script_path = None # @AymenFJA, Confirm that these can be removed?
 
         # Single decision tree - no redundant checks
         if process_templates_config is not None:
@@ -3461,12 +3480,13 @@ class DragonExecutionBackendV3(BaseBackend):
 
         # Register and return
         self._task_registry[uid] = {
+
             "uid": uid,
             "description": task,
             "batch_task": batch_task,
-#            "stdout_path": stdout_path, # @AymenFJA: Confirm that these can be removed?
-#            "stderr_path": stderr_path, # @AymenFJA: Confirm that these can be removed?
-#            "script_path": script_path, # @AymenFJA: Confirm that these can be removed?
+            "stdout_path": stdout_path,
+            "stderr_path": stderr_path,
+            "script_path": script_path,
         }
 
         self.logger.debug(f"Created {execution_mode} task: {uid}")

--- a/tests/integration/test-hpc/conftest.py
+++ b/tests/integration/test-hpc/conftest.py
@@ -1,0 +1,16 @@
+import os
+
+
+def pytest_ignore_collect(collection_path, config):
+    """Skip all HPC tests unless RHAPSODY_HPC=1 is explicitly set.
+
+    This prevents the test-hpc/ subtree from being collected during regular
+    CI runs or local development runs.  The tests require a live Dragon
+    allocation on an HPC cluster and cannot run in GitHub Actions.
+
+    To run on a cluster:
+        RHAPSODY_HPC=1 dragon python3 -m pytest tests/integration/test-hpc/dragon/ -v
+    """
+    if os.environ.get("RHAPSODY_HPC") != "1":
+        return True  # tell pytest to skip this path entirely
+    return None  # normal collection

--- a/tests/integration/test-hpc/dragon/README.md
+++ b/tests/integration/test-hpc/dragon/README.md
@@ -1,0 +1,224 @@
+# RHAPSODY HPC Integration Tests — Dragon Backend
+
+End-to-end integration tests for **RHAPSODY + DragonHPC** on multi-node,
+GPU-enabled HPC systems. These tests exercise the full stack: RHAPSODY's
+session and backend layer, Dragon's Batch scheduler, DDict result transport,
+process template placement, and MPI job orchestration.
+
+This directory is part of a broader `test-hpc/` structure designed to support
+multiple HPC execution backends side by side:
+
+```
+tests/integration/test-hpc/
+├── conftest.py      ← CI gate: entire subtree skipped unless RHAPSODY_HPC=1
+├── dragon/          ← this directory (DragonHPC backend)
+└── flux/            ← planned (Flux backend, same categories)
+```
+
+---
+
+## Prerequisites
+
+| Requirement | Details |
+|-------------|---------|
+| Python | 3.10 – 3.12 (Dragon constraint) |
+| DragonHPC | 0.14.0+ installed in the active environment |
+| RHAPSODY | installed from source (`pip install -e .`) |
+| mpi4py | required only for MPI tests (`pip install mpi4py`) |
+| Active allocation | Dragon global services must be running (`dragon` launcher) |
+
+---
+
+## CI behaviour
+
+These tests are **never collected or run in GitHub Actions**. A parent-level
+`conftest.py` at `tests/integration/test-hpc/conftest.py` uses the
+`pytest_ignore_collect` hook to skip the entire subtree unless the environment
+variable `RHAPSODY_HPC=1` is set. No Makefile or CI YAML changes are needed.
+
+```
+make test-ci        # RHAPSODY_HPC unset → test-hpc/ silently skipped
+make test-regular   # same
+```
+
+---
+
+## Running on an HPC cluster
+
+All commands must be run from the **repository root** with the Dragon launcher.
+Set `RHAPSODY_HPC=1` to unlock collection.
+
+### Step 1 — activate your environment
+
+```bash
+# Example: Cray/NERSC system
+module load python
+source /path/to/your/venv/bin/activate
+```
+
+### Step 2 — obtain an allocation and start Dragon
+
+```bash
+# Example: SLURM allocation with 4 nodes, 4 GPUs each
+salloc -N 4 --gpus-per-node=4 -t 01:00:00
+dragon start   # starts Dragon's global services across the allocation
+```
+
+### Step 3 — run the tests
+
+```bash
+# All standard tests (scale excluded by default)
+RHAPSODY_HPC=1 dragon python3 -m pytest tests/integration/test-hpc/dragon/ -v
+
+# Single category
+RHAPSODY_HPC=1 dragon python3 -m pytest tests/integration/test-hpc/dragon/test_pinning.py -v
+
+# Filter by resource mark
+RHAPSODY_HPC=1 dragon python3 -m pytest tests/integration/test-hpc/dragon/ -m gpu -v
+RHAPSODY_HPC=1 dragon python3 -m pytest tests/integration/test-hpc/dragon/ -m multi_node -v
+RHAPSODY_HPC=1 dragon python3 -m pytest tests/integration/test-hpc/dragon/ -m "not scale" -v
+
+# Scale / stress tests (long-running, off by default)
+RHAPSODY_HPC=1 RHAPSODY_RUN_SCALE=1 dragon python3 -m pytest \
+    tests/integration/test-hpc/dragon/test_scale.py -v -s
+
+# MPI tests only
+RHAPSODY_HPC=1 dragon python3 -m pytest tests/integration/test-hpc/dragon/test_mpi.py -v
+```
+
+---
+
+## File structure
+
+```
+dragon/
+├── conftest.py            # topology detection, shared fixtures, auto-skip logic
+├── hpc_workers.py         # worker functions importable by Dragon remote processes
+├── pytest.ini             # asyncio mode, marker registration, pythonpath = .
+├── test_multinode_gpu.py  # Category 1 — multi-node, multi-GPU execution
+├── test_singlenode_gpu.py # Category 2 — single-node, single-GPU execution
+├── test_pinning.py        # Category 3 — task pinning and GPU affinity
+├── test_scale.py          # Category 4 — scale and stress (10K+ tasks)
+└── test_mpi.py            # Category 5 — MPI integration (mpi4py)
+```
+
+---
+
+## Topology-aware skip logic
+
+Tests auto-skip when the allocation cannot satisfy their resource requirements.
+No manual configuration is needed — topology is detected at runtime from
+`dragon.native.machine.System`.
+
+| Mark | Skipped when |
+|------|-------------|
+| `multi_node` | fewer than 2 nodes detected in the Dragon allocation |
+| `gpu` | no GPU-equipped nodes detected |
+| `mpi` | `mpi4py` not importable |
+| `scale` | `RHAPSODY_RUN_SCALE != 1` |
+
+---
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `RHAPSODY_HPC` | unset | **Must be `1`** for pytest to collect these tests at all |
+| `RHAPSODY_RUN_SCALE` | `0` | Set to `1` to enable scale/stress tests |
+| `RHAPSODY_SCALE_FUNC_COUNT` | `10000` | Function task count for scale tests |
+| `RHAPSODY_SCALE_EXEC_COUNT` | `1000` | Executable task count for scale tests |
+| `RHAPSODY_DDICT_MEM_GB` | `2` (standard) / `4` (scale) | GiB per node for Dragon's results DDict |
+
+---
+
+## Design decisions
+
+### `hpc_workers.py` — why a separate module
+
+Dragon serialises Python functions by **module reference**
+(`hpc_workers.identity`, etc.). When a remote worker on another node
+deserialises the function, it imports `hpc_workers` by name. Functions defined
+directly in test files (e.g. `test_scale.py`) would require `test_scale` to be
+importable on every worker node, which fails on multi-node clusters where the
+test directory is not on `sys.path`. `pytest.ini` sets `pythonpath = .` so
+`hpc_workers.py` (in the same directory) is always importable.
+
+### Pinning tests use executables, not Python functions
+
+Dragon's `batch.process()` — used whenever `process_template` is specified —
+stores the **process exit code** (integer `0`) in the DDict result, not the
+Python function's return value. Node and GPU identity is therefore verified via
+`stdout` (`/bin/hostname`, `echo $CUDA_VISIBLE_DEVICES`). Unpinned function
+tasks use `batch.function()` which correctly captures the Python return value.
+
+### `asyncio_default_test_loop_scope = module`
+
+Module-scoped fixtures (`dragon_backend`, `rhapsody_session`) bind asyncio
+futures to the module event loop. Without setting the test loop scope to
+`module` as well, pytest-asyncio runs each test on its own function-scoped
+loop, causing "future belongs to a different loop" errors.
+
+---
+
+## Full Test Coverage Matrix
+
+**25 tests total** — 21 standard + 4 scale-gated (★)
+
+| # | Test | File | Task Type | Node Scope | GPU | MPI | Scale | What is verified |
+|---|------|------|-----------|-----------|-----|-----|-------|-----------------|
+| 1 | `test_one_task_per_node` | multinode_gpu | Executable (`/bin/hostname`) | All nodes | — | — | — | 1 pinned task/node; stdout = hostname |
+| 2 | `test_one_task_per_gpu_across_nodes` | multinode_gpu | Executable (`/bin/bash`) | All GPU nodes | All GPUs/node | — | — | 1 task/GPU; stdout = `CUDA_VISIBLE_DEVICES` |
+| 3 | `test_concurrent_submission_all_nodes` | multinode_gpu | Executable (`/bin/hostname`) | All nodes | — | — | — | Single `submit_tasks` spans all nodes simultaneously |
+| 4 | `test_executable_pinned_to_first_node` | singlenode_gpu | Executable (`/bin/hostname`) | 1 node | — | — | — | Minimal pinning path; stdout = hostname |
+| 5 | `test_executable_echo_on_first_node` | singlenode_gpu | Executable (`/bin/echo`) | 1 node | — | — | — | Stdout capture; CLI argument forwarding |
+| 6 | `test_function_return_value` | singlenode_gpu | Python function (`add`) | Any | — | — | — | `batch.function()` return value capture |
+| 7 | `test_multiple_function_tasks_return_correct_values` | singlenode_gpu | Python function (`add`) | Any | — | — | — | 10 concurrent tasks; no result corruption |
+| 8 | `test_single_gpu_affinity_on_first_node` | singlenode_gpu | Executable (`/bin/bash`) | 1 GPU node | 1 GPU | — | — | Single GPU affinity; stdout = device ID |
+| 9 | `test_all_gpus_on_first_node` | singlenode_gpu | Executable (`/bin/bash`) | 1 GPU node | All GPUs | — | — | Per-GPU task; each task sees only its GPU |
+| 10 | `test_pin_to_each_node_sequentially` | pinning | Executable (`/bin/hostname`) | All nodes | — | — | — | Sequential pinning correctness per node |
+| 11 | `test_exclusive_node_pinning` | pinning | Executable (`/bin/hostname`) | 2 nodes | — | — | — | Tasks on A ≠ tasks on B; cross-node isolation |
+| 12 | `test_pin_to_specific_gpu` | pinning | Executable (`/bin/bash`) | 1 GPU node | Per GPU | — | — | Each task sees exactly its assigned GPU |
+| 13 | `test_round_robin_gpu_across_nodes` | pinning | Executable (`/bin/bash`) | All GPU nodes | All GPUs/node | — | — | (node, GPU) pair enforced; parsed from stdout |
+| 14 | `test_executable_pinned_to_each_node` | pinning | Executable (`/bin/hostname`) | All nodes | — | — | — | Baseline executable pinning across all nodes |
+| 15 | `test_mpi_gather_single_node` | mpi | Python function (`mpi_gather_hostnames`) | 1 node | — | 2 ranks | — | Gather: all hostnames collected at rank 0 |
+| 16 | `test_mpi_allreduce_single_node` | mpi | Python function (`mpi_allreduce_sum`) | 1 node | — | 4 ranks | — | Allreduce: global sum = n × ranks |
+| 17 | `test_mpi_broadcast_single_node` | mpi | Python function (`mpi_broadcast_check`) | 1 node | — | 4 ranks | — | Broadcast: all ranks receive the correct value |
+| 18 | `test_mpi_gather_across_nodes` | mpi | Python function (`mpi_gather_hostnames`) | All nodes | — | 1 rank/node | — | Each node hostname present in gather result |
+| 19 | `test_mpi_allreduce_across_nodes` | mpi | Python function (`mpi_allreduce_sum`) | All nodes | — | 2 ranks/node | — | Multi-node allreduce sum correctness |
+| 20 | `test_multiple_independent_mpi_jobs` | mpi | Python function (`mpi_gather_hostnames`) | All nodes | — | 1 rank/node | — | 4 concurrent MPI jobs; all complete without interference |
+| 21★ | `test_10k_function_tasks` | scale | Python function (`identity`) | All nodes | — | — | 10,000 | All DONE; `return_value == index` (no result corruption) |
+| 22★ | `test_1k_executable_tasks` | scale | Executable (`/bin/echo`) | All nodes | — | — | 1,000 | All DONE; throughput measured and reported |
+| 23★ | `test_mixed_function_and_executable_tasks` | scale | Mixed | All nodes | — | — | 1,100 | Mixed task types in one submission; all complete |
+| 24★ | `test_wave_submission_stability` | scale | Python function (`identity`) | All nodes | — | — | 10,000 | 10 waves × 1,000 tasks; monitor loop keeps pace with arrivals |
+
+★ scale-gated — requires `RHAPSODY_RUN_SCALE=1`
+
+---
+
+## Coverage Summary
+
+| Dimension | What is covered |
+|-----------|----------------|
+| **Task types** | Python function (`batch.function()`), Executable (`batch.process()`), MPI job (`batch.job()`) |
+| **Node scope** | 1 node · 2 nodes (exclusive isolation) · all nodes (sequential and concurrent) |
+| **GPU scope** | No GPU · 1 GPU · all GPUs on one node · all GPUs across all nodes (round-robin) |
+| **MPI patterns** | gather · allreduce · broadcast · concurrent independent jobs |
+| **MPI ranks** | 2 ranks (single-node) · 4 ranks (single-node) · 1 rank/node · 2 ranks/node (multi-node) |
+| **Scale** | 1 task · 10 tasks · 100 tasks · 1 K executables · 10 K functions · 10 K in waves |
+| **Return value paths** | Exit code (executable) · Python return value (`batch.function()`) · MPI collective result at rank 0 |
+| **Submission patterns** | Sequential · concurrent (single call) · wave (incremental batches) |
+| **Verification methods** | `state == DONE` · stdout content · return value equality · MPI collective correctness |
+
+---
+
+## Known Gaps
+
+| Gap | Description | Priority |
+|-----|-------------|----------|
+| **GPU + MPI combined** | No test pins MPI ranks to specific GPUs (e.g. 1 rank/GPU with `gpu_affinity`) | High |
+| **Task failure propagation** | No test submits an intentionally failing task to verify `FAILED` state, exception capture, and non-blocking delivery of other tasks | High |
+| **Task cancellation** | Cancellation under multi-node and GPU workloads not covered here; see `test_cancel.py` | Medium |
+| **Return value from pinned processes** | `batch.process()` with `process_template` only returns the exit code; Python return values from pinned tasks require a separate communication channel | Medium |
+| **DDict overflow / back-pressure** | No test fills the results DDict past capacity to verify graceful failure | Medium |
+| **Heterogeneous node topologies** | All tests assume homogeneous GPU count per node | Low |
+| **Flux backend parity** | `flux/` sibling directory does not yet exist; the same 25 tests should be ported when the Flux backend matures | Low |

--- a/tests/integration/test-hpc/dragon/README.md
+++ b/tests/integration/test-hpc/dragon/README.md
@@ -61,7 +61,6 @@ source /path/to/your/venv/bin/activate
 ```bash
 # Example: SLURM allocation with 4 nodes, 4 GPUs each
 salloc -N 4 --gpus-per-node=4 -t 01:00:00
-dragon start   # starts Dragon's global services across the allocation
 ```
 
 ### Step 3 — run the tests

--- a/tests/integration/test-hpc/dragon/conftest.py
+++ b/tests/integration/test-hpc/dragon/conftest.py
@@ -1,0 +1,132 @@
+"""
+Shared fixtures and markers for the RHAPSODY + Dragon HPC test suite.
+
+Run with:
+    dragon python3 -m pytest test-hpc/ -v
+
+All topology detection happens here.  Tests never hardcode node counts,
+GPU counts, or hostnames — they skip automatically when the required
+resources are not present in the current allocation.
+"""
+import os
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Custom marks — registered so pytest does not warn about unknown marks
+# ---------------------------------------------------------------------------
+# Usage in test files:
+#   @pytest.mark.multi_node   – skipped when allocation has < 2 nodes
+#   @pytest.mark.gpu          – skipped when no GPUs are detected
+#   @pytest.mark.mpi          – skipped when mpi4py is not importable
+#   @pytest.mark.scale        – long-running scale/stress tests
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "multi_node: require >= 2 nodes in the Dragon allocation")
+    config.addinivalue_line("markers", "gpu: require >= 1 GPU per node")
+    config.addinivalue_line("markers", "mpi: require mpi4py")
+    config.addinivalue_line("markers", "scale: long-running scale and stress tests")
+
+
+# ---------------------------------------------------------------------------
+# Topology detection  (session-scoped — runs once per pytest session)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def topology():
+    """Detect nodes and GPUs from the live Dragon allocation.
+
+    Returns a list of dicts, one per node:
+        [{"huid": int, "hostname": str, "gpus": [int, ...], "num_gpus": int}, ...]
+
+    Raises RuntimeError if Dragon is not initialised.
+    """
+    from dragon.native.machine import Node, System
+
+    nodes = []
+    for huid in System().nodes:
+        node = Node(huid)
+        gpu_ids = list(node.gpus)
+        nodes.append(
+            {
+                "huid": huid,
+                "hostname": node.hostname,
+                "gpus": gpu_ids,
+                "num_gpus": len(gpu_ids),
+            }
+        )
+    assert nodes, "Dragon allocation is empty — no nodes detected"
+    return nodes
+
+
+@pytest.fixture(scope="session")
+def num_nodes(topology):
+    return len(topology)
+
+
+@pytest.fixture(scope="session")
+def gpu_nodes(topology):
+    """Subset of topology entries that have at least one GPU."""
+    return [n for n in topology if n["num_gpus"] > 0]
+
+
+@pytest.fixture(scope="session")
+def total_gpus(gpu_nodes):
+    return sum(n["num_gpus"] for n in gpu_nodes)
+
+
+# ---------------------------------------------------------------------------
+# Automatic skip logic — applied via autouse fixture
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _apply_topology_skips(request, topology, gpu_nodes):
+    """Skip tests whose resource marks cannot be satisfied by the allocation."""
+    if request.node.get_closest_marker("multi_node") and len(topology) < 2:
+        pytest.skip(f"multi_node test requires >= 2 nodes; allocation has {len(topology)}")
+
+    if request.node.get_closest_marker("gpu") and not gpu_nodes:
+        pytest.skip("gpu test requires at least one GPU-equipped node; none detected")
+
+    if request.node.get_closest_marker("mpi"):
+        try:
+            import mpi4py  # noqa: F401
+        except ImportError:
+            pytest.skip("mpi test requires mpi4py; package not available")
+
+
+# ---------------------------------------------------------------------------
+# Backend and session fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+async def dragon_backend(request):
+    """Initialise a DragonExecutionBackendV3 for the test module.
+
+    Scale tests can override batch_kwargs via indirect parametrisation or
+    by setting the RHAPSODY_DDICT_MEM_GB env var (default: 2 GiB/node).
+    """
+    from rhapsody.backends import DragonExecutionBackendV3
+
+    from dragon.native.machine import System
+
+    num_nodes = len(list(System().nodes))
+    ddict_mem_gb = int(os.environ.get("RHAPSODY_DDICT_MEM_GB", 2))
+    ddict_mem = ddict_mem_gb * num_nodes * (1024 ** 3)
+
+    backend = await DragonExecutionBackendV3(
+        batch_kwargs={"results_ddict_mem": ddict_mem}
+    )
+    yield backend
+    await backend.shutdown()
+
+
+@pytest.fixture(scope="module")
+async def rhapsody_session(dragon_backend):
+    """RHAPSODY Session wrapping the module-scoped Dragon backend."""
+    from rhapsody.api import Session
+
+    session = Session(backends=[dragon_backend])
+    yield session
+    # Session is closed by the backend shutdown in dragon_backend fixture

--- a/tests/integration/test-hpc/dragon/conftest.py
+++ b/tests/integration/test-hpc/dragon/conftest.py
@@ -1,5 +1,4 @@
-"""
-Shared fixtures and markers for the RHAPSODY + Dragon HPC test suite.
+"""Shared fixtures and markers for the RHAPSODY + Dragon HPC test suite.
 
 Run with:
     dragon python3 -m pytest test-hpc/ -v
@@ -8,6 +7,7 @@ All topology detection happens here.  Tests never hardcode node counts,
 GPU counts, or hostnames — they skip automatically when the required
 resources are not present in the current allocation.
 """
+
 import os
 
 import pytest
@@ -33,6 +33,7 @@ def pytest_configure(config):
 # Topology detection  (session-scoped — runs once per pytest session)
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(scope="session")
 def topology():
     """Detect nodes and GPUs from the live Dragon allocation.
@@ -42,7 +43,8 @@ def topology():
 
     Raises RuntimeError if Dragon is not initialised.
     """
-    from dragon.native.machine import Node, System
+    from dragon.native.machine import Node
+    from dragon.native.machine import System
 
     nodes = []
     for huid in System().nodes:
@@ -80,6 +82,7 @@ def total_gpus(gpu_nodes):
 # Automatic skip logic — applied via autouse fixture
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(autouse=True)
 def _apply_topology_skips(request, topology, gpu_nodes):
     """Skip tests whose resource marks cannot be satisfied by the allocation."""
@@ -100,24 +103,23 @@ def _apply_topology_skips(request, topology, gpu_nodes):
 # Backend and session fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(scope="module")
 async def dragon_backend(request):
     """Initialise a DragonExecutionBackendV3 for the test module.
 
-    Scale tests can override batch_kwargs via indirect parametrisation or
-    by setting the RHAPSODY_DDICT_MEM_GB env var (default: 2 GiB/node).
+    Scale tests can override batch_kwargs via indirect parametrisation or by setting the
+    RHAPSODY_DDICT_MEM_GB env var (default: 2 GiB/node).
     """
-    from rhapsody.backends import DragonExecutionBackendV3
-
     from dragon.native.machine import System
+
+    from rhapsody.backends import DragonExecutionBackendV3
 
     num_nodes = len(list(System().nodes))
     ddict_mem_gb = int(os.environ.get("RHAPSODY_DDICT_MEM_GB", 2))
-    ddict_mem = ddict_mem_gb * num_nodes * (1024 ** 3)
+    ddict_mem = ddict_mem_gb * num_nodes * (1024**3)
 
-    backend = await DragonExecutionBackendV3(
-        batch_kwargs={"results_ddict_mem": ddict_mem}
-    )
+    backend = await DragonExecutionBackendV3(batch_kwargs={"results_ddict_mem": ddict_mem})
     yield backend
     await backend.shutdown()
 

--- a/tests/integration/test-hpc/dragon/hpc_workers.py
+++ b/tests/integration/test-hpc/dragon/hpc_workers.py
@@ -1,0 +1,89 @@
+"""
+Worker functions that execute inside Dragon's remote worker processes.
+
+All functions used as the `function=` argument in ComputeTask must live here
+(not in test files) because Dragon serialises them by module reference.
+When PYTHONPATH includes the test-hpc directory, every worker node can import
+this module and deserialise the functions successfully.
+
+Rules:
+  - No imports at module level that are unavailable on worker nodes.
+  - Heavy imports (mpi4py, torch, cupy …) go inside the function body.
+  - Functions must be picklable by cloudpickle (all closures captured, no
+    references to pytest fixtures or test-file globals).
+"""
+
+def add(a, b):
+    """Return a + b."""
+    return a + b
+
+
+def identity(n: int) -> int:
+    """Return n unchanged — minimal payload for scheduler stress tests."""
+    return n
+
+
+# ---------------------------------------------------------------------------
+# MPI worker functions
+# ---------------------------------------------------------------------------
+
+def mpi_gather_hostnames() -> dict:
+    """Gather all rank hostnames to rank 0 and return them."""
+    from mpi4py import MPI
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    size = comm.Get_size()
+    host = socket.gethostname()
+
+    all_hosts = comm.gather(host, root=0)
+    if rank == 0:
+        return {"size": size, "hostnames": all_hosts}
+    return None
+
+
+def mpi_allreduce_sum(n: int) -> dict:
+    """Each rank contributes n; allreduce sum returned from rank 0."""
+    from mpi4py import MPI
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    size = comm.Get_size()
+
+    total = comm.allreduce(n, op=MPI.SUM)
+    if rank == 0:
+        return {"size": size, "total": total, "expected": n * size}
+    return None
+
+
+def mpi_broadcast_check(value: int) -> bool:
+    """Rank 0 broadcasts value; all ranks verify receipt; rank 0 returns result."""
+    from mpi4py import MPI
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+
+    data = value if rank == 0 else None
+    data = comm.bcast(data, root=0)
+    correct = data == value
+
+    all_correct = comm.gather(correct, root=0)
+    if rank == 0:
+        return all(all_correct)
+    return None
+
+
+def mpi_scatter_and_gather(data_per_rank: list) -> list:
+    """Scatter data_per_rank to all ranks; double each element; gather back."""
+    from mpi4py import MPI
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+
+    scattered = comm.scatter(data_per_rank if rank == 0 else None, root=0)
+    processed = scattered * 2
+
+    gathered = comm.gather(processed, root=0)
+    if rank == 0:
+        return gathered
+    return None

--- a/tests/integration/test-hpc/dragon/hpc_workers.py
+++ b/tests/integration/test-hpc/dragon/hpc_workers.py
@@ -1,5 +1,4 @@
-"""
-Worker functions that execute inside Dragon's remote worker processes.
+"""Worker functions that execute inside Dragon's remote worker processes.
 
 All functions used as the `function=` argument in ComputeTask must live here
 (not in test files) because Dragon serialises them by module reference.
@@ -12,6 +11,7 @@ Rules:
   - Functions must be picklable by cloudpickle (all closures captured, no
     references to pytest fixtures or test-file globals).
 """
+
 
 def add(a, b):
     """Return a + b."""
@@ -27,8 +27,11 @@ def identity(n: int) -> int:
 # MPI worker functions
 # ---------------------------------------------------------------------------
 
+
 def mpi_gather_hostnames() -> dict:
     """Gather all rank hostnames to rank 0 and return them."""
+    import socket
+
     from mpi4py import MPI
 
     comm = MPI.COMM_WORLD

--- a/tests/integration/test-hpc/dragon/pytest.ini
+++ b/tests/integration/test-hpc/dragon/pytest.ini
@@ -1,0 +1,11 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = module
+asyncio_default_test_loop_scope = module
+markers =
+    multi_node: require >= 2 nodes in the Dragon allocation
+    gpu: require >= 1 GPU per node
+    mpi: require mpi4py
+    scale: long-running scale and stress tests (enable with RHAPSODY_RUN_SCALE=1)
+log_cli = true
+log_cli_level = INFO

--- a/tests/integration/test-hpc/dragon/test_mpi.py
+++ b/tests/integration/test-hpc/dragon/test_mpi.py
@@ -1,0 +1,250 @@
+"""
+Category 5 — MPI integration tests (mpi4py).
+
+Purpose:
+    Validate that RHAPSODY can launch MPI jobs through Dragon's batch.job()
+    API, that mpi4py communication patterns work correctly across ranks, and
+    that multi-node MPI jobs distribute ranks across nodes as expected.
+
+Execution strategy:
+    Tasks use process_templates (plural) to specify (nranks, ProcessTemplate)
+    tuples per node.  Each worker function uses mpi4py to perform standard
+    communication patterns (gather, scatter, broadcast, allreduce).
+
+    Results are written to a shared DDict or returned as the function's
+    return value from rank 0.
+
+Resource requirements:
+    mpi mark — skipped when mpi4py is not importable.
+    Multi-node MPI tests require multi_node mark.
+
+Expected outcomes:
+    - All MPI ranks start and finish cleanly.
+    - Communication results match expected values.
+    - No deadlocks or rank mismatches within the timeout.
+
+Run:
+    dragon python3 -m pytest test-hpc/test_mpi.py -v
+"""
+import pytest
+
+from hpc_workers import (
+    mpi_gather_hostnames as _mpi_gather_hostnames,
+    mpi_allreduce_sum as _mpi_allreduce_sum,
+    mpi_broadcast_check as _mpi_broadcast_check,
+    mpi_scatter_and_gather as _mpi_scatter_and_gather,
+)
+
+
+# ---------------------------------------------------------------------------
+# Single-node MPI tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.mpi
+@pytest.mark.asyncio
+async def test_mpi_gather_single_node(rhapsody_session, topology):
+    """2-rank MPI job on one node: gather hostnames to rank 0."""
+    from rhapsody.api import ComputeTask
+    from dragon.infrastructure.policy import Policy
+
+    node = topology[0]
+    ranks = 2
+
+    task = ComputeTask(
+        function=_mpi_gather_hostnames,
+        task_backend_specific_kwargs={
+            "process_templates": [
+                (ranks, {"policy": Policy(
+                    placement=Policy.Placement.HOST_NAME,
+                    host_name=node["hostname"],
+                )})
+            ]
+        },
+    )
+
+    await rhapsody_session.submit_tasks([task])
+    await rhapsody_session.wait_tasks([task], timeout=120.0)
+
+    assert task["state"] == "DONE"
+    result = task["return_value"]
+    assert result is not None, "rank 0 returned None"
+    assert result["size"] == ranks
+    assert len(result["hostnames"]) == ranks
+    assert all(h == node["hostname"] for h in result["hostnames"]), (
+        f"Expected all ranks on {node['hostname']!r}, "
+        f"got: {result['hostnames']}"
+    )
+
+
+@pytest.mark.mpi
+@pytest.mark.asyncio
+async def test_mpi_allreduce_single_node(rhapsody_session, topology):
+    """4-rank MPI allreduce on one node: sum must equal ranks * input value."""
+    from rhapsody.api import ComputeTask
+    from dragon.infrastructure.policy import Policy
+
+    node = topology[0]
+    ranks = 4
+    input_val = 7
+
+    task = ComputeTask(
+        function=_mpi_allreduce_sum,
+        args=(input_val,),
+        task_backend_specific_kwargs={
+            "process_templates": [
+                (ranks, {"policy": Policy(
+                    placement=Policy.Placement.HOST_NAME,
+                    host_name=node["hostname"],
+                )})
+            ]
+        },
+    )
+
+    await rhapsody_session.submit_tasks([task])
+    await rhapsody_session.wait_tasks([task], timeout=120.0)
+
+    assert task["state"] == "DONE"
+    result = task["return_value"]
+    assert result["total"] == result["expected"], (
+        f"Allreduce sum {result['total']} != expected {result['expected']}"
+    )
+
+
+@pytest.mark.mpi
+@pytest.mark.asyncio
+async def test_mpi_broadcast_single_node(rhapsody_session, topology):
+    """Broadcast from rank 0 to all ranks on one node; verify all received."""
+    from rhapsody.api import ComputeTask
+    from dragon.infrastructure.policy import Policy
+
+    node = topology[0]
+    ranks = 4
+
+    task = ComputeTask(
+        function=_mpi_broadcast_check,
+        args=(42,),
+        task_backend_specific_kwargs={
+            "process_templates": [
+                (ranks, {"policy": Policy(
+                    placement=Policy.Placement.HOST_NAME,
+                    host_name=node["hostname"],
+                )})
+            ]
+        },
+    )
+
+    await rhapsody_session.submit_tasks([task])
+    await rhapsody_session.wait_tasks([task], timeout=120.0)
+
+    assert task["state"] == "DONE"
+    assert task["return_value"] is True, "Not all ranks received the broadcast value"
+
+
+# ---------------------------------------------------------------------------
+# Multi-node MPI tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.mpi
+@pytest.mark.multi_node
+@pytest.mark.asyncio
+async def test_mpi_gather_across_nodes(rhapsody_session, topology):
+    """1 rank per node, gather hostnames to rank 0; confirm each node is represented."""
+    from rhapsody.api import ComputeTask
+    from dragon.infrastructure.policy import Policy
+
+    ranks_per_node = 1
+    expected_hosts = {node["hostname"] for node in topology}
+
+    task = ComputeTask(
+        function=_mpi_gather_hostnames,
+        task_backend_specific_kwargs={
+            "process_templates": [
+                (ranks_per_node, {"policy": Policy(
+                    placement=Policy.Placement.HOST_NAME,
+                    host_name=node["hostname"],
+                )})
+                for node in topology
+            ]
+        },
+    )
+
+    await rhapsody_session.submit_tasks([task])
+    await rhapsody_session.wait_tasks([task], timeout=180.0)
+
+    assert task["state"] == "DONE"
+    result = task["return_value"]
+    assert result["size"] == len(topology) * ranks_per_node
+    observed_hosts = set(result["hostnames"])
+    assert observed_hosts == expected_hosts, (
+        f"Missing nodes in MPI gather. "
+        f"Expected: {expected_hosts}, got: {observed_hosts}"
+    )
+
+
+@pytest.mark.mpi
+@pytest.mark.multi_node
+@pytest.mark.asyncio
+async def test_mpi_allreduce_across_nodes(rhapsody_session, topology):
+    """Multi-node allreduce: 2 ranks per node, verify global sum."""
+    from rhapsody.api import ComputeTask
+    from dragon.infrastructure.policy import Policy
+
+    ranks_per_node = 2
+    input_val = 3
+    total_ranks = len(topology) * ranks_per_node
+
+    task = ComputeTask(
+        function=_mpi_allreduce_sum,
+        args=(input_val,),
+        task_backend_specific_kwargs={
+            "process_templates": [
+                (ranks_per_node, {"policy": Policy(
+                    placement=Policy.Placement.HOST_NAME,
+                    host_name=node["hostname"],
+                )})
+                for node in topology
+            ]
+        },
+    )
+
+    await rhapsody_session.submit_tasks([task])
+    await rhapsody_session.wait_tasks([task], timeout=180.0)
+
+    assert task["state"] == "DONE"
+    result = task["return_value"]
+    assert result["total"] == input_val * total_ranks, (
+        f"Expected allreduce sum {input_val * total_ranks}, got {result['total']}"
+    )
+
+
+@pytest.mark.mpi
+@pytest.mark.multi_node
+@pytest.mark.asyncio
+async def test_multiple_independent_mpi_jobs(rhapsody_session, topology):
+    """Submit multiple independent MPI jobs concurrently; all must complete."""
+    from rhapsody.api import ComputeTask
+    from dragon.infrastructure.policy import Policy
+
+    n_jobs = 4
+    tasks = []
+
+    for job_id in range(n_jobs):
+        task = ComputeTask(
+            function=_mpi_gather_hostnames,
+            task_backend_specific_kwargs={
+                "process_templates": [
+                    (1, {"policy": Policy(
+                        placement=Policy.Placement.HOST_NAME,
+                        host_name=node["hostname"],
+                    )})
+                    for node in topology
+                ]
+            },
+        )
+        tasks.append(task)
+
+    await rhapsody_session.submit_tasks(tasks)
+    await rhapsody_session.wait_tasks(tasks, timeout=300.0)
+
+    failed = [t for t in tasks if t["state"] != "DONE"]
+    assert not failed, f"{len(failed)}/{n_jobs} concurrent MPI jobs failed"

--- a/tests/integration/test-hpc/dragon/test_mpi.py
+++ b/tests/integration/test-hpc/dragon/test_mpi.py
@@ -1,5 +1,4 @@
-"""
-Category 5 — MPI integration tests (mpi4py).
+"""Category 5 — MPI integration tests (mpi4py).
 
 Purpose:
     Validate that RHAPSODY can launch MPI jobs through Dragon's batch.job()
@@ -26,26 +25,25 @@ Expected outcomes:
 Run:
     dragon python3 -m pytest test-hpc/test_mpi.py -v
 """
+
 import pytest
-
-from hpc_workers import (
-    mpi_gather_hostnames as _mpi_gather_hostnames,
-    mpi_allreduce_sum as _mpi_allreduce_sum,
-    mpi_broadcast_check as _mpi_broadcast_check,
-    mpi_scatter_and_gather as _mpi_scatter_and_gather,
-)
-
+from hpc_workers import mpi_allreduce_sum as _mpi_allreduce_sum
+from hpc_workers import mpi_broadcast_check as _mpi_broadcast_check
+from hpc_workers import mpi_gather_hostnames as _mpi_gather_hostnames
+from hpc_workers import mpi_scatter_and_gather as _mpi_scatter_and_gather
 
 # ---------------------------------------------------------------------------
 # Single-node MPI tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.mpi
 @pytest.mark.asyncio
 async def test_mpi_gather_single_node(rhapsody_session, topology):
     """2-rank MPI job on one node: gather hostnames to rank 0."""
-    from rhapsody.api import ComputeTask
     from dragon.infrastructure.policy import Policy
+
+    from rhapsody.api import ComputeTask
 
     node = topology[0]
     ranks = 2
@@ -54,10 +52,15 @@ async def test_mpi_gather_single_node(rhapsody_session, topology):
         function=_mpi_gather_hostnames,
         task_backend_specific_kwargs={
             "process_templates": [
-                (ranks, {"policy": Policy(
-                    placement=Policy.Placement.HOST_NAME,
-                    host_name=node["hostname"],
-                )})
+                (
+                    ranks,
+                    {
+                        "policy": Policy(
+                            placement=Policy.Placement.HOST_NAME,
+                            host_name=node["hostname"],
+                        )
+                    },
+                )
             ]
         },
     )
@@ -71,8 +74,7 @@ async def test_mpi_gather_single_node(rhapsody_session, topology):
     assert result["size"] == ranks
     assert len(result["hostnames"]) == ranks
     assert all(h == node["hostname"] for h in result["hostnames"]), (
-        f"Expected all ranks on {node['hostname']!r}, "
-        f"got: {result['hostnames']}"
+        f"Expected all ranks on {node['hostname']!r}, got: {result['hostnames']}"
     )
 
 
@@ -80,8 +82,9 @@ async def test_mpi_gather_single_node(rhapsody_session, topology):
 @pytest.mark.asyncio
 async def test_mpi_allreduce_single_node(rhapsody_session, topology):
     """4-rank MPI allreduce on one node: sum must equal ranks * input value."""
-    from rhapsody.api import ComputeTask
     from dragon.infrastructure.policy import Policy
+
+    from rhapsody.api import ComputeTask
 
     node = topology[0]
     ranks = 4
@@ -92,10 +95,15 @@ async def test_mpi_allreduce_single_node(rhapsody_session, topology):
         args=(input_val,),
         task_backend_specific_kwargs={
             "process_templates": [
-                (ranks, {"policy": Policy(
-                    placement=Policy.Placement.HOST_NAME,
-                    host_name=node["hostname"],
-                )})
+                (
+                    ranks,
+                    {
+                        "policy": Policy(
+                            placement=Policy.Placement.HOST_NAME,
+                            host_name=node["hostname"],
+                        )
+                    },
+                )
             ]
         },
     )
@@ -114,8 +122,9 @@ async def test_mpi_allreduce_single_node(rhapsody_session, topology):
 @pytest.mark.asyncio
 async def test_mpi_broadcast_single_node(rhapsody_session, topology):
     """Broadcast from rank 0 to all ranks on one node; verify all received."""
-    from rhapsody.api import ComputeTask
     from dragon.infrastructure.policy import Policy
+
+    from rhapsody.api import ComputeTask
 
     node = topology[0]
     ranks = 4
@@ -125,10 +134,15 @@ async def test_mpi_broadcast_single_node(rhapsody_session, topology):
         args=(42,),
         task_backend_specific_kwargs={
             "process_templates": [
-                (ranks, {"policy": Policy(
-                    placement=Policy.Placement.HOST_NAME,
-                    host_name=node["hostname"],
-                )})
+                (
+                    ranks,
+                    {
+                        "policy": Policy(
+                            placement=Policy.Placement.HOST_NAME,
+                            host_name=node["hostname"],
+                        )
+                    },
+                )
             ]
         },
     )
@@ -144,13 +158,15 @@ async def test_mpi_broadcast_single_node(rhapsody_session, topology):
 # Multi-node MPI tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.mpi
 @pytest.mark.multi_node
 @pytest.mark.asyncio
 async def test_mpi_gather_across_nodes(rhapsody_session, topology):
     """1 rank per node, gather hostnames to rank 0; confirm each node is represented."""
-    from rhapsody.api import ComputeTask
     from dragon.infrastructure.policy import Policy
+
+    from rhapsody.api import ComputeTask
 
     ranks_per_node = 1
     expected_hosts = {node["hostname"] for node in topology}
@@ -159,10 +175,15 @@ async def test_mpi_gather_across_nodes(rhapsody_session, topology):
         function=_mpi_gather_hostnames,
         task_backend_specific_kwargs={
             "process_templates": [
-                (ranks_per_node, {"policy": Policy(
-                    placement=Policy.Placement.HOST_NAME,
-                    host_name=node["hostname"],
-                )})
+                (
+                    ranks_per_node,
+                    {
+                        "policy": Policy(
+                            placement=Policy.Placement.HOST_NAME,
+                            host_name=node["hostname"],
+                        )
+                    },
+                )
                 for node in topology
             ]
         },
@@ -176,8 +197,7 @@ async def test_mpi_gather_across_nodes(rhapsody_session, topology):
     assert result["size"] == len(topology) * ranks_per_node
     observed_hosts = set(result["hostnames"])
     assert observed_hosts == expected_hosts, (
-        f"Missing nodes in MPI gather. "
-        f"Expected: {expected_hosts}, got: {observed_hosts}"
+        f"Missing nodes in MPI gather. Expected: {expected_hosts}, got: {observed_hosts}"
     )
 
 
@@ -186,8 +206,9 @@ async def test_mpi_gather_across_nodes(rhapsody_session, topology):
 @pytest.mark.asyncio
 async def test_mpi_allreduce_across_nodes(rhapsody_session, topology):
     """Multi-node allreduce: 2 ranks per node, verify global sum."""
-    from rhapsody.api import ComputeTask
     from dragon.infrastructure.policy import Policy
+
+    from rhapsody.api import ComputeTask
 
     ranks_per_node = 2
     input_val = 3
@@ -198,10 +219,15 @@ async def test_mpi_allreduce_across_nodes(rhapsody_session, topology):
         args=(input_val,),
         task_backend_specific_kwargs={
             "process_templates": [
-                (ranks_per_node, {"policy": Policy(
-                    placement=Policy.Placement.HOST_NAME,
-                    host_name=node["hostname"],
-                )})
+                (
+                    ranks_per_node,
+                    {
+                        "policy": Policy(
+                            placement=Policy.Placement.HOST_NAME,
+                            host_name=node["hostname"],
+                        )
+                    },
+                )
                 for node in topology
             ]
         },
@@ -222,21 +248,27 @@ async def test_mpi_allreduce_across_nodes(rhapsody_session, topology):
 @pytest.mark.asyncio
 async def test_multiple_independent_mpi_jobs(rhapsody_session, topology):
     """Submit multiple independent MPI jobs concurrently; all must complete."""
-    from rhapsody.api import ComputeTask
     from dragon.infrastructure.policy import Policy
+
+    from rhapsody.api import ComputeTask
 
     n_jobs = 4
     tasks = []
 
-    for job_id in range(n_jobs):
+    for _ in range(n_jobs):
         task = ComputeTask(
             function=_mpi_gather_hostnames,
             task_backend_specific_kwargs={
                 "process_templates": [
-                    (1, {"policy": Policy(
-                        placement=Policy.Placement.HOST_NAME,
-                        host_name=node["hostname"],
-                    )})
+                    (
+                        1,
+                        {
+                            "policy": Policy(
+                                placement=Policy.Placement.HOST_NAME,
+                                host_name=node["hostname"],
+                            )
+                        },
+                    )
                     for node in topology
                 ]
             },

--- a/tests/integration/test-hpc/dragon/test_multinode_gpu.py
+++ b/tests/integration/test-hpc/dragon/test_multinode_gpu.py
@@ -1,0 +1,138 @@
+"""
+Category 1 — Multi-node, multi-GPU execution tests.
+
+Purpose:
+    Validate that RHAPSODY can distribute tasks across every node in the
+    allocation, that each task lands on the correct node, and that GPU
+    affinity is correctly enforced when GPUs are present.
+
+Execution strategy:
+    Pinning is done via HOST_NAME Policy inside process_template.
+    Dragon's batch.process() returns the process exit code (0), not the
+    Python function return value — so node identity is verified via stdout
+    (e.g. /bin/hostname) rather than return_value.
+
+Resource requirements:
+    >= 2 nodes (multi_node mark), >= 1 GPU per node (gpu mark for GPU tests).
+
+Expected outcomes:
+    - Every task reaches DONE state.
+    - stdout of each task contains the hostname it was pinned to.
+    - Each GPU task has non-empty CUDA_VISIBLE_DEVICES in its stdout.
+
+Run:
+    dragon python3 -m pytest test-hpc/test_multinode_gpu.py -v
+"""
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.multi_node
+@pytest.mark.asyncio
+async def test_one_task_per_node(rhapsody_session, topology):
+    """Each node receives one pinned executable task; stdout contains the hostname."""
+    from dragon.infrastructure.policy import Policy
+    from rhapsody.api import ComputeTask
+
+    tasks = [
+        ComputeTask(
+            executable="/bin/hostname",
+            task_backend_specific_kwargs={
+                "process_template": {
+                    "policy": Policy(
+                        placement=Policy.Placement.HOST_NAME,
+                        host_name=node["hostname"],
+                    )
+                }
+            },
+        )
+        for node in topology
+    ]
+
+    await rhapsody_session.submit_tasks(tasks)
+    results = await rhapsody_session.wait_tasks(tasks, timeout=120.0)
+
+    assert len(results) == len(topology)
+    for task, node in zip(results, topology):
+        assert task["state"] == "DONE", f"Task on {node['hostname']} did not reach DONE"
+        stdout = (task.get("stdout") or "").strip()
+        assert node["hostname"] in stdout, (
+            f"Expected hostname {node['hostname']!r} in stdout, got {stdout!r}"
+        )
+
+
+@pytest.mark.multi_node
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_one_task_per_gpu_across_nodes(rhapsody_session, gpu_nodes):
+    """One task per GPU node; stdout shows non-empty CUDA_VISIBLE_DEVICES."""
+    from dragon.infrastructure.policy import Policy
+    from rhapsody.api import ComputeTask
+
+    tasks = []
+    expected = []
+
+    for node in gpu_nodes:
+        task = ComputeTask(
+            executable="/bin/bash",
+            arguments=["-c", "echo $CUDA_VISIBLE_DEVICES"],
+            task_backend_specific_kwargs={
+                "process_template": {
+                    "policy": Policy(
+                        placement=Policy.Placement.HOST_NAME,
+                        host_name=node["hostname"],
+                        gpu_affinity=node["gpus"],
+                    )
+                }
+            },
+        )
+        tasks.append(task)
+        expected.append(node)
+
+    await rhapsody_session.submit_tasks(tasks)
+    results = await rhapsody_session.wait_tasks(tasks, timeout=120.0)
+
+    assert len(results) == len(gpu_nodes)
+    for task, node in zip(results, expected):
+        assert task["state"] == "DONE"
+        stdout = (task.get("stdout") or "").strip()
+        assert stdout not in ("", "NOT_SET"), (
+            f"Node {node['hostname']}: CUDA_VISIBLE_DEVICES was empty in stdout — "
+            f"GPU affinity not enforced"
+        )
+
+
+@pytest.mark.multi_node
+@pytest.mark.asyncio
+async def test_concurrent_submission_all_nodes(rhapsody_session, topology):
+    """Submit tasks to all nodes in one call; all complete and each returns its hostname."""
+    from dragon.infrastructure.policy import Policy
+    from rhapsody.api import ComputeTask
+
+    tasks = [
+        ComputeTask(
+            executable="/bin/hostname",
+            task_backend_specific_kwargs={
+                "process_template": {
+                    "policy": Policy(
+                        placement=Policy.Placement.HOST_NAME,
+                        host_name=node["hostname"],
+                    )
+                }
+            },
+        )
+        for node in topology
+    ]
+
+    await rhapsody_session.submit_tasks(tasks)
+    await rhapsody_session.wait_tasks(tasks, timeout=120.0)
+
+    for task, node in zip(tasks, topology):
+        assert task["state"] == "DONE"
+        stdout = (task.get("stdout") or "").strip()
+        assert node["hostname"] in stdout, (
+            f"Pinning violated: expected {node['hostname']!r} in stdout, got {stdout!r}"
+        )

--- a/tests/integration/test-hpc/dragon/test_multinode_gpu.py
+++ b/tests/integration/test-hpc/dragon/test_multinode_gpu.py
@@ -1,5 +1,4 @@
-"""
-Category 1 — Multi-node, multi-GPU execution tests.
+"""Category 1 — Multi-node, multi-GPU execution tests.
 
 Purpose:
     Validate that RHAPSODY can distribute tasks across every node in the
@@ -23,18 +22,20 @@ Expected outcomes:
 Run:
     dragon python3 -m pytest test-hpc/test_multinode_gpu.py -v
 """
-import pytest
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.multi_node
 @pytest.mark.asyncio
 async def test_one_task_per_node(rhapsody_session, topology):
     """Each node receives one pinned executable task; stdout contains the hostname."""
     from dragon.infrastructure.policy import Policy
+
     from rhapsody.api import ComputeTask
 
     tasks = [
@@ -70,6 +71,7 @@ async def test_one_task_per_node(rhapsody_session, topology):
 async def test_one_task_per_gpu_across_nodes(rhapsody_session, gpu_nodes):
     """One task per GPU node; stdout shows non-empty CUDA_VISIBLE_DEVICES."""
     from dragon.infrastructure.policy import Policy
+
     from rhapsody.api import ComputeTask
 
     tasks = []
@@ -110,6 +112,7 @@ async def test_one_task_per_gpu_across_nodes(rhapsody_session, gpu_nodes):
 async def test_concurrent_submission_all_nodes(rhapsody_session, topology):
     """Submit tasks to all nodes in one call; all complete and each returns its hostname."""
     from dragon.infrastructure.policy import Policy
+
     from rhapsody.api import ComputeTask
 
     tasks = [

--- a/tests/integration/test-hpc/dragon/test_pinning.py
+++ b/tests/integration/test-hpc/dragon/test_pinning.py
@@ -1,0 +1,231 @@
+"""
+Category 3 — Task pinning and affinity tests.
+
+Purpose:
+    Verify that placement constraints are strictly enforced by Dragon and
+    respected by RHAPSODY's process_template forwarding.
+
+Execution strategy:
+    All pinning tests use executables (not Python functions) because
+    Dragon's batch.process() returns the process exit code, not the
+    Python function return value.  Node/GPU identity is verified via stdout.
+
+    - Node pinning: /bin/hostname → stdout contains expected hostname
+    - GPU pinning:  'echo $CUDA_VISIBLE_DEVICES' → stdout is non-empty
+    - Combined:     'echo $(hostname):$CUDA_VISIBLE_DEVICES' → parsed from stdout
+
+Resource requirements:
+    Node pinning: single node minimum.
+    Multi-node pinning: multi_node mark.
+    GPU tests: gpu mark.
+
+Expected outcomes:
+    - Each task's stdout contains the hostname/GPU it was pinned to.
+    - No task lands outside its declared placement constraint.
+
+Run:
+    dragon python3 -m pytest test-hpc/test_pinning.py -v
+"""
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Node pinning
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_pin_to_each_node_sequentially(rhapsody_session, topology):
+    """One /bin/hostname task per node; stdout must match the pinned hostname."""
+    from dragon.infrastructure.policy import Policy
+    from rhapsody.api import ComputeTask
+
+    tasks = [
+        ComputeTask(
+            executable="/bin/hostname",
+            task_backend_specific_kwargs={
+                "process_template": {
+                    "policy": Policy(
+                        placement=Policy.Placement.HOST_NAME,
+                        host_name=node["hostname"],
+                    )
+                }
+            },
+        )
+        for node in topology
+    ]
+
+    await rhapsody_session.submit_tasks(tasks)
+    await rhapsody_session.wait_tasks(tasks, timeout=120.0)
+
+    for task, node in zip(tasks, topology):
+        assert task["state"] == "DONE"
+        stdout = (task.get("stdout") or "").strip()
+        assert node["hostname"] in stdout, (
+            f"Pinning violated: expected {node['hostname']!r} in stdout, got {stdout!r}"
+        )
+
+
+@pytest.mark.multi_node
+@pytest.mark.asyncio
+async def test_exclusive_node_pinning(rhapsody_session, topology):
+    """Tasks pinned to node[0] and node[1] must land on different nodes."""
+    from dragon.infrastructure.policy import Policy
+    from rhapsody.api import ComputeTask
+
+    node_a = topology[0]
+    node_b = topology[1]
+
+    task_a = ComputeTask(
+        executable="/bin/hostname",
+        task_backend_specific_kwargs={
+            "process_template": {
+                "policy": Policy(
+                    placement=Policy.Placement.HOST_NAME,
+                    host_name=node_a["hostname"],
+                )
+            }
+        },
+    )
+    task_b = ComputeTask(
+        executable="/bin/hostname",
+        task_backend_specific_kwargs={
+            "process_template": {
+                "policy": Policy(
+                    placement=Policy.Placement.HOST_NAME,
+                    host_name=node_b["hostname"],
+                )
+            }
+        },
+    )
+
+    await rhapsody_session.submit_tasks([task_a, task_b])
+    await rhapsody_session.wait_tasks([task_a, task_b], timeout=60.0)
+
+    stdout_a = (task_a.get("stdout") or "").strip()
+    stdout_b = (task_b.get("stdout") or "").strip()
+
+    assert node_a["hostname"] in stdout_a, f"task_a landed on wrong node: {stdout_a!r}"
+    assert node_b["hostname"] in stdout_b, f"task_b landed on wrong node: {stdout_b!r}"
+    assert stdout_a != stdout_b, "Both tasks reported the same hostname — pinning had no effect"
+
+
+# ---------------------------------------------------------------------------
+# GPU affinity
+# ---------------------------------------------------------------------------
+
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_pin_to_specific_gpu(rhapsody_session, gpu_nodes):
+    """One task per GPU on the first GPU node; each stdout shows its GPU assignment."""
+    from dragon.infrastructure.policy import Policy
+    from rhapsody.api import ComputeTask
+
+    node = gpu_nodes[0]
+    tasks = [
+        ComputeTask(
+            executable="/bin/bash",
+            arguments=["-c", "echo $CUDA_VISIBLE_DEVICES"],
+            task_backend_specific_kwargs={
+                "process_template": {
+                    "policy": Policy(
+                        placement=Policy.Placement.HOST_NAME,
+                        host_name=node["hostname"],
+                        gpu_affinity=[gpu_id],
+                    )
+                }
+            },
+        )
+        for gpu_id in node["gpus"]
+    ]
+
+    await rhapsody_session.submit_tasks(tasks)
+    await rhapsody_session.wait_tasks(tasks, timeout=120.0)
+
+    for task in tasks:
+        assert task["state"] == "DONE"
+        stdout = (task.get("stdout") or "").strip()
+        assert stdout not in ("", "NOT_SET"), (
+            "GPU affinity not enforced: CUDA_VISIBLE_DEVICES is empty in stdout"
+        )
+
+
+@pytest.mark.multi_node
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_round_robin_gpu_across_nodes(rhapsody_session, gpu_nodes):
+    """One task per (node, GPU) pair; stdout contains 'hostname:CUDA_VISIBLE_DEVICES'."""
+    from dragon.infrastructure.policy import Policy
+    from rhapsody.api import ComputeTask
+
+    tasks = []
+    expected_hosts = []
+
+    for node in gpu_nodes:
+        for gpu_id in node["gpus"]:
+            task = ComputeTask(
+                executable="/bin/bash",
+                arguments=["-c", "echo $(hostname):$CUDA_VISIBLE_DEVICES"],
+                task_backend_specific_kwargs={
+                    "process_template": {
+                        "policy": Policy(
+                            placement=Policy.Placement.HOST_NAME,
+                            host_name=node["hostname"],
+                            gpu_affinity=[gpu_id],
+                        )
+                    }
+                },
+            )
+            tasks.append(task)
+            expected_hosts.append(node["hostname"])
+
+    await rhapsody_session.submit_tasks(tasks)
+    await rhapsody_session.wait_tasks(tasks, timeout=180.0)
+
+    for task, exp_host in zip(tasks, expected_hosts):
+        assert task["state"] == "DONE"
+        stdout = (task.get("stdout") or "").strip()
+        # stdout format: "hostname:CUDA_VISIBLE_DEVICES"
+        assert ":" in stdout, f"Unexpected stdout format: {stdout!r}"
+        ret_host, ret_gpu = stdout.split(":", 1)
+        assert exp_host in ret_host, (
+            f"Hostname mismatch: expected {exp_host!r}, got {ret_host!r}"
+        )
+        assert ret_gpu not in ("", "NOT_SET"), (
+            f"GPU affinity missing on node {exp_host!r}: CUDA_VISIBLE_DEVICES={ret_gpu!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Executable pinning (baseline)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_executable_pinned_to_each_node(rhapsody_session, topology):
+    """/bin/hostname pinned to each node; stdout contains the expected hostname."""
+    from dragon.infrastructure.policy import Policy
+    from rhapsody.api import ComputeTask
+
+    tasks = [
+        ComputeTask(
+            executable="/bin/hostname",
+            task_backend_specific_kwargs={
+                "process_template": {
+                    "policy": Policy(
+                        placement=Policy.Placement.HOST_NAME,
+                        host_name=node["hostname"],
+                    )
+                }
+            },
+        )
+        for node in topology
+    ]
+
+    await rhapsody_session.submit_tasks(tasks)
+    await rhapsody_session.wait_tasks(tasks, timeout=120.0)
+
+    for task, node in zip(tasks, topology):
+        assert task["state"] == "DONE"
+        stdout = (task.get("stdout") or "").strip()
+        assert node["hostname"] in stdout, (
+            f"Expected hostname {node['hostname']!r} in stdout, got {stdout!r}"
+        )

--- a/tests/integration/test-hpc/dragon/test_pinning.py
+++ b/tests/integration/test-hpc/dragon/test_pinning.py
@@ -1,5 +1,4 @@
-"""
-Category 3 — Task pinning and affinity tests.
+"""Category 3 — Task pinning and affinity tests.
 
 Purpose:
     Verify that placement constraints are strictly enforced by Dragon and
@@ -26,17 +25,19 @@ Expected outcomes:
 Run:
     dragon python3 -m pytest test-hpc/test_pinning.py -v
 """
-import pytest
 
+import pytest
 
 # ---------------------------------------------------------------------------
 # Node pinning
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_pin_to_each_node_sequentially(rhapsody_session, topology):
     """One /bin/hostname task per node; stdout must match the pinned hostname."""
     from dragon.infrastructure.policy import Policy
+
     from rhapsody.api import ComputeTask
 
     tasks = [
@@ -70,6 +71,7 @@ async def test_pin_to_each_node_sequentially(rhapsody_session, topology):
 async def test_exclusive_node_pinning(rhapsody_session, topology):
     """Tasks pinned to node[0] and node[1] must land on different nodes."""
     from dragon.infrastructure.policy import Policy
+
     from rhapsody.api import ComputeTask
 
     node_a = topology[0]
@@ -113,11 +115,13 @@ async def test_exclusive_node_pinning(rhapsody_session, topology):
 # GPU affinity
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.gpu
 @pytest.mark.asyncio
 async def test_pin_to_specific_gpu(rhapsody_session, gpu_nodes):
     """One task per GPU on the first GPU node; each stdout shows its GPU assignment."""
     from dragon.infrastructure.policy import Policy
+
     from rhapsody.api import ComputeTask
 
     node = gpu_nodes[0]
@@ -155,6 +159,7 @@ async def test_pin_to_specific_gpu(rhapsody_session, gpu_nodes):
 async def test_round_robin_gpu_across_nodes(rhapsody_session, gpu_nodes):
     """One task per (node, GPU) pair; stdout contains 'hostname:CUDA_VISIBLE_DEVICES'."""
     from dragon.infrastructure.policy import Policy
+
     from rhapsody.api import ComputeTask
 
     tasks = []
@@ -187,9 +192,7 @@ async def test_round_robin_gpu_across_nodes(rhapsody_session, gpu_nodes):
         # stdout format: "hostname:CUDA_VISIBLE_DEVICES"
         assert ":" in stdout, f"Unexpected stdout format: {stdout!r}"
         ret_host, ret_gpu = stdout.split(":", 1)
-        assert exp_host in ret_host, (
-            f"Hostname mismatch: expected {exp_host!r}, got {ret_host!r}"
-        )
+        assert exp_host in ret_host, f"Hostname mismatch: expected {exp_host!r}, got {ret_host!r}"
         assert ret_gpu not in ("", "NOT_SET"), (
             f"GPU affinity missing on node {exp_host!r}: CUDA_VISIBLE_DEVICES={ret_gpu!r}"
         )
@@ -199,10 +202,12 @@ async def test_round_robin_gpu_across_nodes(rhapsody_session, gpu_nodes):
 # Executable pinning (baseline)
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_executable_pinned_to_each_node(rhapsody_session, topology):
     """/bin/hostname pinned to each node; stdout contains the expected hostname."""
     from dragon.infrastructure.policy import Policy
+
     from rhapsody.api import ComputeTask
 
     tasks = [

--- a/tests/integration/test-hpc/dragon/test_scale.py
+++ b/tests/integration/test-hpc/dragon/test_scale.py
@@ -1,5 +1,4 @@
-"""
-Category 4 — Scale and stress tests.
+"""Category 4 — Scale and stress tests.
 
 Purpose:
     Evaluate RHAPSODY + Dragon correctness and scheduling stability under
@@ -35,13 +34,12 @@ Expected outcomes:
 Run:
     RHAPSODY_RUN_SCALE=1 dragon python3 -m pytest test-hpc/test_scale.py -v -s
 """
+
 import os
 import time
 
 import pytest
-
 from hpc_workers import identity as _identity
-
 
 # ---------------------------------------------------------------------------
 # Scale-test gate — skip unless explicitly enabled
@@ -54,24 +52,24 @@ EXEC_COUNT = int(os.environ.get("RHAPSODY_SCALE_EXEC_COUNT", 1_000))
 
 def _scale_skip():
     if not SCALE_ENABLED:
-        pytest.skip(
-            "Scale tests disabled. Set RHAPSODY_RUN_SCALE=1 to enable."
-        )
+        pytest.skip("Scale tests disabled. Set RHAPSODY_RUN_SCALE=1 to enable.")
 
 
 # ---------------------------------------------------------------------------
 # Fixtures — scale tests use a dedicated backend with more DDict memory
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(scope="module")
 async def scale_backend():
     """DragonExecutionBackendV3 with enlarged results DDict for scale tests."""
     from dragon.native.machine import System
+
     from rhapsody.backends import DragonExecutionBackendV3
 
     num_nodes = len(list(System().nodes))
     ddict_gb = int(os.environ.get("RHAPSODY_DDICT_MEM_GB", 4))
-    ddict_mem = ddict_gb * num_nodes * (1024 ** 3)
+    ddict_mem = ddict_gb * num_nodes * (1024**3)
 
     backend = await DragonExecutionBackendV3(
         batch_kwargs={
@@ -95,6 +93,7 @@ async def scale_session(scale_backend):
 # Tests
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.scale
 @pytest.mark.asyncio
 async def test_10k_function_tasks(scale_session):
@@ -114,22 +113,19 @@ async def test_10k_function_tasks(scale_session):
     # Allow up to 5 minutes for all tasks to complete
     results = await scale_session.wait_tasks(tasks, timeout=300.0)
     total_elapsed = time.perf_counter() - t0
-    print(f"  total elapsed: {total_elapsed:.2f}s  "
-          f"({FUNC_COUNT / total_elapsed:,.0f} tasks/s)", flush=True)
+    print(
+        f"  total elapsed: {total_elapsed:.2f}s  ({FUNC_COUNT / total_elapsed:,.0f} tasks/s)",
+        flush=True,
+    )
 
     failed = [t for t in results if t["state"] != "DONE"]
     assert not failed, f"{len(failed)}/{FUNC_COUNT} tasks did not reach DONE"
 
     # Verify every return value — detect any result corruption
     wrong = [
-        (i, tasks[i]["return_value"])
-        for i in range(FUNC_COUNT)
-        if tasks[i]["return_value"] != i
+        (i, tasks[i]["return_value"]) for i in range(FUNC_COUNT) if tasks[i]["return_value"] != i
     ]
-    assert not wrong, (
-        f"{len(wrong)} tasks had wrong return values. "
-        f"First 5: {wrong[:5]}"
-    )
+    assert not wrong, f"{len(wrong)} tasks had wrong return values. First 5: {wrong[:5]}"
 
 
 @pytest.mark.scale
@@ -142,8 +138,7 @@ async def test_1k_executable_tasks(scale_session):
     print(f"\nSubmitting {EXEC_COUNT:,} executable tasks...", flush=True)
 
     tasks = [
-        ComputeTask(executable="/bin/echo", arguments=[f"task-{i}"])
-        for i in range(EXEC_COUNT)
+        ComputeTask(executable="/bin/echo", arguments=[f"task-{i}"]) for i in range(EXEC_COUNT)
     ]
 
     t0 = time.perf_counter()
@@ -153,8 +148,10 @@ async def test_1k_executable_tasks(scale_session):
 
     results = await scale_session.wait_tasks(tasks, timeout=300.0)
     total_elapsed = time.perf_counter() - t0
-    print(f"  total elapsed: {total_elapsed:.2f}s  "
-          f"({EXEC_COUNT / total_elapsed:,.0f} tasks/s)", flush=True)
+    print(
+        f"  total elapsed: {total_elapsed:.2f}s  ({EXEC_COUNT / total_elapsed:,.0f} tasks/s)",
+        flush=True,
+    )
 
     failed = [t for t in results if t["state"] != "DONE"]
     assert not failed, f"{len(failed)}/{EXEC_COUNT} executable tasks did not reach DONE"
@@ -167,13 +164,12 @@ async def test_mixed_function_and_executable_tasks(scale_session):
     _scale_skip()
     from rhapsody.api import ComputeTask
 
-    n_func = FUNC_COUNT // 10    # 1/10 of the full scale to keep runtime reasonable
+    n_func = FUNC_COUNT // 10  # 1/10 of the full scale to keep runtime reasonable
     n_exec = EXEC_COUNT // 10
 
     func_tasks = [ComputeTask(function=_identity, args=(i,)) for i in range(n_func)]
     exec_tasks = [
-        ComputeTask(executable="/bin/echo", arguments=[f"exec-{i}"])
-        for i in range(n_exec)
+        ComputeTask(executable="/bin/echo", arguments=[f"exec-{i}"]) for i in range(n_exec)
     ]
     all_tasks = func_tasks + exec_tasks
 
@@ -191,8 +187,8 @@ async def test_mixed_function_and_executable_tasks(scale_session):
 async def test_wave_submission_stability(scale_session):
     """Submit tasks in waves (batches of 1000) to test sustained throughput.
 
-    Simulates a workflow where tasks arrive incrementally rather than all
-    at once.  Validates that the monitor loop keeps pace with new submissions.
+    Simulates a workflow where tasks arrive incrementally rather than all at once.  Validates that
+    the monitor loop keeps pace with new submissions.
     """
     _scale_skip()
     from rhapsody.api import ComputeTask
@@ -206,8 +202,7 @@ async def test_wave_submission_stability(scale_session):
 
     for wave in range(num_waves):
         wave_tasks = [
-            ComputeTask(function=_identity, args=(wave * wave_size + i,))
-            for i in range(wave_size)
+            ComputeTask(function=_identity, args=(wave * wave_size + i,)) for i in range(wave_size)
         ]
         await scale_session.submit_tasks(wave_tasks)
         all_tasks.extend(wave_tasks)
@@ -217,8 +212,10 @@ async def test_wave_submission_stability(scale_session):
     results = await scale_session.wait_tasks(all_tasks, timeout=300.0)
     elapsed = time.perf_counter() - t0
     total = len(all_tasks)
-    print(f"  {total:,} tasks completed in {elapsed:.2f}s "
-          f"({total / elapsed:,.0f} tasks/s)", flush=True)
+    print(
+        f"  {total:,} tasks completed in {elapsed:.2f}s ({total / elapsed:,.0f} tasks/s)",
+        flush=True,
+    )
 
     failed = [t for t in results if t["state"] != "DONE"]
     assert not failed, f"{len(failed)}/{total} wave tasks failed"

--- a/tests/integration/test-hpc/dragon/test_scale.py
+++ b/tests/integration/test-hpc/dragon/test_scale.py
@@ -1,0 +1,224 @@
+"""
+Category 4 — Scale and stress tests.
+
+Purpose:
+    Evaluate RHAPSODY + Dragon correctness and scheduling stability under
+    high task counts.  Confirms that:
+      - All submitted tasks reach DONE (no silent drops)
+      - Return values are correct for every task (no result corruption)
+      - The system remains responsive throughout the run
+      - result DDict does not overflow under load
+
+Execution strategy:
+    Tests are parametrised by task count.  The backend is created with an
+    enlarged results_ddict_mem (controlled by RHAPSODY_DDICT_MEM_GB env var,
+    default 4 GiB/node) to accommodate high task volumes.
+
+    Tasks are lightweight by design: the goal is to stress the scheduling
+    pipeline, not the compute.  Each function returns a deterministic value
+    so correctness can be verified per-task without relying on ordering.
+
+Resource requirements:
+    scale mark — long-running, not run by default.
+    Set RHAPSODY_RUN_SCALE=1 to enable, or use -m scale.
+
+Thresholds (configurable via env vars):
+    RHAPSODY_SCALE_FUNC_COUNT   default 10_000  (function invocations)
+    RHAPSODY_SCALE_EXEC_COUNT   default 1_000   (executable task runs)
+
+Expected outcomes:
+    - All tasks: state == "DONE"
+    - Function tasks: return_value == task index (no corruption)
+    - Executable tasks: exit code 0, stdout contains expected string
+    - No TimeoutError within the configured deadline
+
+Run:
+    RHAPSODY_RUN_SCALE=1 dragon python3 -m pytest test-hpc/test_scale.py -v -s
+"""
+import os
+import time
+
+import pytest
+
+from hpc_workers import identity as _identity
+
+
+# ---------------------------------------------------------------------------
+# Scale-test gate — skip unless explicitly enabled
+# ---------------------------------------------------------------------------
+
+SCALE_ENABLED = os.environ.get("RHAPSODY_RUN_SCALE", "0") == "1"
+FUNC_COUNT = int(os.environ.get("RHAPSODY_SCALE_FUNC_COUNT", 10_000))
+EXEC_COUNT = int(os.environ.get("RHAPSODY_SCALE_EXEC_COUNT", 1_000))
+
+
+def _scale_skip():
+    if not SCALE_ENABLED:
+        pytest.skip(
+            "Scale tests disabled. Set RHAPSODY_RUN_SCALE=1 to enable."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — scale tests use a dedicated backend with more DDict memory
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+async def scale_backend():
+    """DragonExecutionBackendV3 with enlarged results DDict for scale tests."""
+    from dragon.native.machine import System
+    from rhapsody.backends import DragonExecutionBackendV3
+
+    num_nodes = len(list(System().nodes))
+    ddict_gb = int(os.environ.get("RHAPSODY_DDICT_MEM_GB", 4))
+    ddict_mem = ddict_gb * num_nodes * (1024 ** 3)
+
+    backend = await DragonExecutionBackendV3(
+        batch_kwargs={
+            "results_ddict_mem": ddict_mem,
+            "scheduler_workers": num_nodes * 4,
+        }
+    )
+    yield backend
+    await backend.shutdown()
+
+
+@pytest.fixture(scope="module")
+async def scale_session(scale_backend):
+    from rhapsody.api import Session
+
+    session = Session(backends=[scale_backend])
+    yield session
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.scale
+@pytest.mark.asyncio
+async def test_10k_function_tasks(scale_session):
+    """Submit FUNC_COUNT function tasks; verify every result is correct."""
+    _scale_skip()
+    from rhapsody.api import ComputeTask
+
+    print(f"\nSubmitting {FUNC_COUNT:,} function tasks...", flush=True)
+
+    tasks = [ComputeTask(function=_identity, args=(i,)) for i in range(FUNC_COUNT)]
+
+    t0 = time.perf_counter()
+    await scale_session.submit_tasks(tasks)
+    submit_elapsed = time.perf_counter() - t0
+    print(f"  submit_tasks: {submit_elapsed:.2f}s", flush=True)
+
+    # Allow up to 5 minutes for all tasks to complete
+    results = await scale_session.wait_tasks(tasks, timeout=300.0)
+    total_elapsed = time.perf_counter() - t0
+    print(f"  total elapsed: {total_elapsed:.2f}s  "
+          f"({FUNC_COUNT / total_elapsed:,.0f} tasks/s)", flush=True)
+
+    failed = [t for t in results if t["state"] != "DONE"]
+    assert not failed, f"{len(failed)}/{FUNC_COUNT} tasks did not reach DONE"
+
+    # Verify every return value — detect any result corruption
+    wrong = [
+        (i, tasks[i]["return_value"])
+        for i in range(FUNC_COUNT)
+        if tasks[i]["return_value"] != i
+    ]
+    assert not wrong, (
+        f"{len(wrong)} tasks had wrong return values. "
+        f"First 5: {wrong[:5]}"
+    )
+
+
+@pytest.mark.scale
+@pytest.mark.asyncio
+async def test_1k_executable_tasks(scale_session):
+    """Submit EXEC_COUNT executable tasks (/bin/echo); verify all complete."""
+    _scale_skip()
+    from rhapsody.api import ComputeTask
+
+    print(f"\nSubmitting {EXEC_COUNT:,} executable tasks...", flush=True)
+
+    tasks = [
+        ComputeTask(executable="/bin/echo", arguments=[f"task-{i}"])
+        for i in range(EXEC_COUNT)
+    ]
+
+    t0 = time.perf_counter()
+    await scale_session.submit_tasks(tasks)
+    submit_elapsed = time.perf_counter() - t0
+    print(f"  submit_tasks: {submit_elapsed:.2f}s", flush=True)
+
+    results = await scale_session.wait_tasks(tasks, timeout=300.0)
+    total_elapsed = time.perf_counter() - t0
+    print(f"  total elapsed: {total_elapsed:.2f}s  "
+          f"({EXEC_COUNT / total_elapsed:,.0f} tasks/s)", flush=True)
+
+    failed = [t for t in results if t["state"] != "DONE"]
+    assert not failed, f"{len(failed)}/{EXEC_COUNT} executable tasks did not reach DONE"
+
+
+@pytest.mark.scale
+@pytest.mark.asyncio
+async def test_mixed_function_and_executable_tasks(scale_session):
+    """Interleave function and executable tasks in a single submission."""
+    _scale_skip()
+    from rhapsody.api import ComputeTask
+
+    n_func = FUNC_COUNT // 10    # 1/10 of the full scale to keep runtime reasonable
+    n_exec = EXEC_COUNT // 10
+
+    func_tasks = [ComputeTask(function=_identity, args=(i,)) for i in range(n_func)]
+    exec_tasks = [
+        ComputeTask(executable="/bin/echo", arguments=[f"exec-{i}"])
+        for i in range(n_exec)
+    ]
+    all_tasks = func_tasks + exec_tasks
+
+    print(f"\nMixed submission: {n_func} function + {n_exec} executable", flush=True)
+
+    await scale_session.submit_tasks(all_tasks)
+    results = await scale_session.wait_tasks(all_tasks, timeout=180.0)
+
+    failed = [t for t in results if t["state"] != "DONE"]
+    assert not failed, f"{len(failed)}/{len(all_tasks)} mixed tasks failed"
+
+
+@pytest.mark.scale
+@pytest.mark.asyncio
+async def test_wave_submission_stability(scale_session):
+    """Submit tasks in waves (batches of 1000) to test sustained throughput.
+
+    Simulates a workflow where tasks arrive incrementally rather than all
+    at once.  Validates that the monitor loop keeps pace with new submissions.
+    """
+    _scale_skip()
+    from rhapsody.api import ComputeTask
+
+    wave_size = 1_000
+    num_waves = FUNC_COUNT // wave_size
+    all_tasks = []
+
+    print(f"\nWave submission: {num_waves} waves × {wave_size} tasks", flush=True)
+    t0 = time.perf_counter()
+
+    for wave in range(num_waves):
+        wave_tasks = [
+            ComputeTask(function=_identity, args=(wave * wave_size + i,))
+            for i in range(wave_size)
+        ]
+        await scale_session.submit_tasks(wave_tasks)
+        all_tasks.extend(wave_tasks)
+
+    print(f"  all waves submitted in {time.perf_counter() - t0:.2f}s", flush=True)
+
+    results = await scale_session.wait_tasks(all_tasks, timeout=300.0)
+    elapsed = time.perf_counter() - t0
+    total = len(all_tasks)
+    print(f"  {total:,} tasks completed in {elapsed:.2f}s "
+          f"({total / elapsed:,.0f} tasks/s)", flush=True)
+
+    failed = [t for t in results if t["state"] != "DONE"]
+    assert not failed, f"{len(failed)}/{total} wave tasks failed"

--- a/tests/integration/test-hpc/dragon/test_singlenode_gpu.py
+++ b/tests/integration/test-hpc/dragon/test_singlenode_gpu.py
@@ -1,5 +1,4 @@
-"""
-Category 2 — Single-node, single-GPU tests.
+"""Category 2 — Single-node, single-GPU tests.
 
 Purpose:
     Validate correctness on the minimal execution configuration: one node,
@@ -28,19 +27,20 @@ Expected outcomes:
 Run:
     dragon python3 -m pytest test-hpc/test_singlenode_gpu.py -v
 """
+
 import pytest
-
 from hpc_workers import add as _add
-
 
 # ---------------------------------------------------------------------------
 # Pinned executable tests — verify node placement via stdout
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_executable_pinned_to_first_node(rhapsody_session, topology):
     """/bin/hostname pinned to the first node; stdout contains its hostname."""
     from dragon.infrastructure.policy import Policy
+
     from rhapsody.api import ComputeTask
 
     node = topology[0]
@@ -61,15 +61,14 @@ async def test_executable_pinned_to_first_node(rhapsody_session, topology):
 
     assert results[0]["state"] == "DONE"
     stdout = (results[0].get("stdout") or "").strip()
-    assert node["hostname"] in stdout, (
-        f"Expected {node['hostname']!r} in stdout, got {stdout!r}"
-    )
+    assert node["hostname"] in stdout, f"Expected {node['hostname']!r} in stdout, got {stdout!r}"
 
 
 @pytest.mark.asyncio
 async def test_executable_echo_on_first_node(rhapsody_session, topology):
     """/bin/echo with arguments runs on first node and stdout is captured."""
     from dragon.infrastructure.policy import Policy
+
     from rhapsody.api import ComputeTask
 
     node = topology[0]
@@ -96,6 +95,7 @@ async def test_executable_echo_on_first_node(rhapsody_session, topology):
 # ---------------------------------------------------------------------------
 # Unpinned function tests — verify return value capture via batch.function()
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_function_return_value(rhapsody_session):
@@ -133,11 +133,13 @@ async def test_multiple_function_tasks_return_correct_values(rhapsody_session):
 # GPU affinity tests — verify via stdout
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.gpu
 @pytest.mark.asyncio
 async def test_single_gpu_affinity_on_first_node(rhapsody_session, gpu_nodes):
     """Task pinned to the first GPU of the first GPU node; stdout shows CUDA_VISIBLE_DEVICES."""
     from dragon.infrastructure.policy import Policy
+
     from rhapsody.api import ComputeTask
 
     node = gpu_nodes[0]
@@ -172,6 +174,7 @@ async def test_single_gpu_affinity_on_first_node(rhapsody_session, gpu_nodes):
 async def test_all_gpus_on_first_node(rhapsody_session, gpu_nodes):
     """One task per GPU on the first GPU node; each stdout shows its assigned GPU."""
     from dragon.infrastructure.policy import Policy
+
     from rhapsody.api import ComputeTask
 
     node = gpu_nodes[0]

--- a/tests/integration/test-hpc/dragon/test_singlenode_gpu.py
+++ b/tests/integration/test-hpc/dragon/test_singlenode_gpu.py
@@ -1,0 +1,203 @@
+"""
+Category 2 — Single-node, single-GPU tests.
+
+Purpose:
+    Validate correctness on the minimal execution configuration: one node,
+    one GPU.
+
+Execution strategy:
+    Two complementary patterns are used:
+
+    1. Pinned executable tasks (process_template + Policy):
+       Dragon's batch.process() returns the process exit code, not a Python
+       return value.  Node/GPU verification is done via stdout.
+
+    2. Unpinned function tasks (no process_template):
+       batch.function() captures the Python return value correctly.
+       Used to validate argument passing and return value integrity.
+
+Resource requirements:
+    Always runnable (single node is always present).
+    GPU sub-tests require >= 1 GPU (gpu mark).
+
+Expected outcomes:
+    - Pinned executable tasks: state == DONE, stdout contains expected string.
+    - Unpinned function tasks: state == DONE, return_value matches expectation.
+    - GPU tasks: non-empty CUDA_VISIBLE_DEVICES in stdout.
+
+Run:
+    dragon python3 -m pytest test-hpc/test_singlenode_gpu.py -v
+"""
+import pytest
+
+from hpc_workers import add as _add
+
+
+# ---------------------------------------------------------------------------
+# Pinned executable tests — verify node placement via stdout
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_executable_pinned_to_first_node(rhapsody_session, topology):
+    """/bin/hostname pinned to the first node; stdout contains its hostname."""
+    from dragon.infrastructure.policy import Policy
+    from rhapsody.api import ComputeTask
+
+    node = topology[0]
+    task = ComputeTask(
+        executable="/bin/hostname",
+        task_backend_specific_kwargs={
+            "process_template": {
+                "policy": Policy(
+                    placement=Policy.Placement.HOST_NAME,
+                    host_name=node["hostname"],
+                )
+            }
+        },
+    )
+
+    await rhapsody_session.submit_tasks([task])
+    results = await rhapsody_session.wait_tasks([task], timeout=60.0)
+
+    assert results[0]["state"] == "DONE"
+    stdout = (results[0].get("stdout") or "").strip()
+    assert node["hostname"] in stdout, (
+        f"Expected {node['hostname']!r} in stdout, got {stdout!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_executable_echo_on_first_node(rhapsody_session, topology):
+    """/bin/echo with arguments runs on first node and stdout is captured."""
+    from dragon.infrastructure.policy import Policy
+    from rhapsody.api import ComputeTask
+
+    node = topology[0]
+    task = ComputeTask(
+        executable="/bin/echo",
+        arguments=["hello-rhapsody"],
+        task_backend_specific_kwargs={
+            "process_template": {
+                "policy": Policy(
+                    placement=Policy.Placement.HOST_NAME,
+                    host_name=node["hostname"],
+                )
+            }
+        },
+    )
+
+    await rhapsody_session.submit_tasks([task])
+    results = await rhapsody_session.wait_tasks([task], timeout=60.0)
+
+    assert results[0]["state"] == "DONE"
+    assert "hello-rhapsody" in (results[0].get("stdout") or "")
+
+
+# ---------------------------------------------------------------------------
+# Unpinned function tests — verify return value capture via batch.function()
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_function_return_value(rhapsody_session):
+    """batch.function() correctly captures the Python return value."""
+    from rhapsody.api import ComputeTask
+
+    task = ComputeTask(function=_add, args=(21, 21))
+
+    await rhapsody_session.submit_tasks([task])
+    results = await rhapsody_session.wait_tasks([task], timeout=60.0)
+
+    assert results[0]["state"] == "DONE"
+    assert results[0]["return_value"] == 42
+
+
+@pytest.mark.asyncio
+async def test_multiple_function_tasks_return_correct_values(rhapsody_session):
+    """Multiple concurrent function tasks all return correct independent values."""
+    from rhapsody.api import ComputeTask
+
+    pairs = [(i, i * 2) for i in range(10)]
+    tasks = [ComputeTask(function=_add, args=(a, b)) for a, b in pairs]
+
+    await rhapsody_session.submit_tasks(tasks)
+    results = await rhapsody_session.wait_tasks(tasks, timeout=60.0)
+
+    for task, (a, b) in zip(results, pairs):
+        assert task["state"] == "DONE"
+        assert task["return_value"] == a + b, (
+            f"_add({a}, {b}) returned {task['return_value']!r}, expected {a + b}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# GPU affinity tests — verify via stdout
+# ---------------------------------------------------------------------------
+
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_single_gpu_affinity_on_first_node(rhapsody_session, gpu_nodes):
+    """Task pinned to the first GPU of the first GPU node; stdout shows CUDA_VISIBLE_DEVICES."""
+    from dragon.infrastructure.policy import Policy
+    from rhapsody.api import ComputeTask
+
+    node = gpu_nodes[0]
+    first_gpu = [node["gpus"][0]]
+
+    task = ComputeTask(
+        executable="/bin/bash",
+        arguments=["-c", "echo $CUDA_VISIBLE_DEVICES"],
+        task_backend_specific_kwargs={
+            "process_template": {
+                "policy": Policy(
+                    placement=Policy.Placement.HOST_NAME,
+                    host_name=node["hostname"],
+                    gpu_affinity=first_gpu,
+                )
+            }
+        },
+    )
+
+    await rhapsody_session.submit_tasks([task])
+    results = await rhapsody_session.wait_tasks([task], timeout=60.0)
+
+    assert results[0]["state"] == "DONE"
+    stdout = (results[0].get("stdout") or "").strip()
+    assert stdout not in ("", "NOT_SET"), (
+        f"CUDA_VISIBLE_DEVICES was {stdout!r} — GPU affinity not enforced"
+    )
+
+
+@pytest.mark.gpu
+@pytest.mark.asyncio
+async def test_all_gpus_on_first_node(rhapsody_session, gpu_nodes):
+    """One task per GPU on the first GPU node; each stdout shows its assigned GPU."""
+    from dragon.infrastructure.policy import Policy
+    from rhapsody.api import ComputeTask
+
+    node = gpu_nodes[0]
+    tasks = [
+        ComputeTask(
+            executable="/bin/bash",
+            arguments=["-c", "echo $CUDA_VISIBLE_DEVICES"],
+            task_backend_specific_kwargs={
+                "process_template": {
+                    "policy": Policy(
+                        placement=Policy.Placement.HOST_NAME,
+                        host_name=node["hostname"],
+                        gpu_affinity=[gpu_id],
+                    )
+                }
+            },
+        )
+        for gpu_id in node["gpus"]
+    ]
+
+    await rhapsody_session.submit_tasks(tasks)
+    results = await rhapsody_session.wait_tasks(tasks, timeout=120.0)
+
+    for task in results:
+        assert task["state"] == "DONE"
+        stdout = (task.get("stdout") or "").strip()
+        assert stdout not in ("", "NOT_SET"), (
+            "At least one GPU task had empty CUDA_VISIBLE_DEVICES in stdout"
+        )

--- a/tests/unit/test_backend_execution_dragon.py
+++ b/tests/unit/test_backend_execution_dragon.py
@@ -83,7 +83,7 @@ def backend_v3():
         backend = DragonExecutionBackendV3()
 
     backend._callback_func = MagicMock()
-    backend._loop = asyncio.get_event_loop()
+    backend._loop = asyncio.new_event_loop()
     return backend
 
 

--- a/tests/unit/test_backend_execution_dragon.py
+++ b/tests/unit/test_backend_execution_dragon.py
@@ -576,25 +576,47 @@ async def test_process_template_combined_spec_policy_cwd_args(session_v3):
 # ============================================================================
 
 
-def test_v3_constructor_accepts_new_params_and_forwards_to_batch():
-    """num_nodes, pool_nodes, and disable_telemetry are accepted and forwarded to Batch."""
+def test_v3_constructor_batch_kwargs_forwarded_verbatim():
+    """batch_kwargs contents are splatted into Batch() unchanged."""
     from rhapsody.backends.execution.dragon import DragonExecutionBackendV3
 
     mock_batch = MagicMock()
     mock_batch.num_workers = 8
     mock_batch.num_managers = 1
 
+    kwargs = {"num_nodes": 4, "pool_nodes": 2, "disable_telem": True, "scheduler_workers": 2}
+
     with patch(
         "rhapsody.backends.execution.dragon.Batch", return_value=mock_batch
     ) as mock_batch_cls:
-        backend = DragonExecutionBackendV3(num_nodes=4, pool_nodes=2, disable_telemetry=True)
+        backend = DragonExecutionBackendV3(batch_kwargs=kwargs)
 
-    mock_batch_cls.assert_called_once_with(num_nodes=4, pool_nodes=2, disable_telem=True)
+    mock_batch_cls.assert_called_once_with(**kwargs)
     assert backend.batch is mock_batch
 
 
-def test_v3_constructor_rejects_removed_params():
-    """num_workers, disable_background_batching, and disable_batch_submission no longer exist."""
+def test_v3_constructor_no_batch_kwargs_calls_batch_with_no_args():
+    """DragonExecutionBackendV3() with no args calls Batch() with no args."""
+    from rhapsody.backends.execution.dragon import DragonExecutionBackendV3
+
+    mock_batch = MagicMock()
+    mock_batch.num_workers = 4
+    mock_batch.num_managers = 1
+
+    with patch(
+        "rhapsody.backends.execution.dragon.Batch", return_value=mock_batch
+    ) as mock_batch_cls:
+        DragonExecutionBackendV3()
+
+    mock_batch_cls.assert_called_once_with()
+
+
+def test_v3_constructor_rejects_bare_batch_params():
+    """Batch params passed directly (not via batch_kwargs) raise TypeError.
+
+    num_nodes, pool_nodes, disable_telemetry, and other old top-level params are no longer accepted
+    as direct constructor arguments — they must go through batch_kwargs.
+    """
     from rhapsody.backends.execution.dragon import DragonExecutionBackendV3
 
     mock_batch = MagicMock()
@@ -602,6 +624,12 @@ def test_v3_constructor_rejects_removed_params():
     mock_batch.num_managers = 1
 
     with patch("rhapsody.backends.execution.dragon.Batch", return_value=mock_batch):
+        with pytest.raises(TypeError):
+            DragonExecutionBackendV3(num_nodes=4)
+        with pytest.raises(TypeError):
+            DragonExecutionBackendV3(pool_nodes=2)
+        with pytest.raises(TypeError):
+            DragonExecutionBackendV3(disable_telemetry=True)
         with pytest.raises(TypeError):
             DragonExecutionBackendV3(num_workers=4)
         with pytest.raises(TypeError):
@@ -684,6 +712,225 @@ def test_v3_fence_delegates_to_batch(backend_v3):
     """backend.fence() calls batch.fence() exactly once."""
     backend_v3.fence()
     backend_v3.batch.fence.assert_called_once()
+
+
+def test_v3_monitor_loop_skips_task_with_no_manager_idx(backend_v3):
+    """Monitor loop skips a task whose manager_idx is not yet set (None)."""
+    mock_task = MagicMock()
+    mock_task.core.manager_idx = None
+    uid = "task.monitor-no-idx"
+    backend_v3._monitored_batches[uid] = (mock_task, "flow-uid")
+
+    # Run one sweep manually
+    backend_v3.batch.results_ddict.manager.side_effect = AssertionError("should not be called")
+    batch_tuids = list(backend_v3._monitored_batches.keys())
+    completed = []
+    for tuid in batch_tuids:
+        if tuid not in backend_v3._monitored_batches:
+            continue
+        batch_task, flow_uid = backend_v3._monitored_batches[tuid]
+        manager_idx = batch_task.core.manager_idx
+        if manager_idx is None:
+            continue
+        ddict_shard_idx = 0 if manager_idx == -1 else manager_idx
+        try:
+            result, tb, raised, stdout, stderr = backend_v3.batch.results_ddict.manager(
+                ddict_shard_idx
+            )[tuid]
+        except KeyError:
+            continue
+        backend_v3._monitored_batches.pop(tuid)
+        completed.append((flow_uid, result, tb, raised, stdout, stderr))
+
+    assert completed == []
+    assert uid in backend_v3._monitored_batches  # not consumed
+
+
+def test_v3_monitor_loop_routes_to_correct_shard(backend_v3):
+    """Monitor loop calls results_ddict.manager(shard_idx) with the task's manager_idx."""
+    mock_task = MagicMock()
+    mock_task.core.manager_idx = 2
+    uid = "task.monitor-shard"
+    backend_v3._monitored_batches[uid] = (mock_task, "flow-uid-2")
+
+    mock_shard = MagicMock()
+    mock_shard.__getitem__ = MagicMock(return_value=("result", None, False, "", ""))
+    backend_v3.batch.results_ddict.manager.return_value = mock_shard
+
+    batch_tuids = list(backend_v3._monitored_batches.keys())
+    completed = []
+    for tuid in batch_tuids:
+        if tuid not in backend_v3._monitored_batches:
+            continue
+        batch_task, flow_uid = backend_v3._monitored_batches[tuid]
+        manager_idx = batch_task.core.manager_idx
+        if manager_idx is None:
+            continue
+        ddict_shard_idx = 0 if manager_idx == -1 else manager_idx
+        try:
+            result, tb, raised, stdout, stderr = backend_v3.batch.results_ddict.manager(
+                ddict_shard_idx
+            )[tuid]
+        except KeyError:
+            continue
+        backend_v3._monitored_batches.pop(tuid)
+        completed.append((flow_uid, result, tb, raised, stdout, stderr))
+
+    backend_v3.batch.results_ddict.manager.assert_called_once_with(2)
+    assert len(completed) == 1
+    assert completed[0][0] == "flow-uid-2"
+    assert completed[0][1] == "result"
+
+
+def test_v3_monitor_loop_scheduler_manager_maps_to_shard_0(backend_v3):
+    """SCHEDULER_MANAGER_IDX (-1) maps to DDict shard 0."""
+    mock_task = MagicMock()
+    mock_task.core.manager_idx = -1  # SCHEDULER_MANAGER_IDX
+    uid = "task.monitor-scheduler"
+    backend_v3._monitored_batches[uid] = (mock_task, "flow-sched")
+
+    mock_shard = MagicMock()
+    mock_shard.__getitem__ = MagicMock(return_value=("sched-result", None, False, "", ""))
+    backend_v3.batch.results_ddict.manager.return_value = mock_shard
+
+    batch_tuids = list(backend_v3._monitored_batches.keys())
+    for tuid in batch_tuids:
+        if tuid not in backend_v3._monitored_batches:
+            continue
+        batch_task, _ = backend_v3._monitored_batches[tuid]
+        manager_idx = batch_task.core.manager_idx
+        if manager_idx is None:
+            continue
+        ddict_shard_idx = 0 if manager_idx == -1 else manager_idx
+        try:
+            backend_v3.batch.results_ddict.manager(ddict_shard_idx)[tuid]
+        except KeyError:
+            continue
+
+    backend_v3.batch.results_ddict.manager.assert_called_once_with(0)
+
+
+@pytest.mark.asyncio
+async def test_v3_cancel_task_calls_dragon_cancel(backend_v3):
+    """cancel_task delegates to batch_task.cancel() and fires CANCELED callback on success.
+
+    The callback must be called synchronously — no asyncio.sleep(0) needed to observe it. This
+    verifies that TaskStateManager.update_task (when bound) runs inline on the event loop.
+
+    After cancellation the task must be removed from both _task_registry and _monitored_batches so
+    the monitor loop stops polling its DDict entry (blocking IPC for a cancelled task would stall
+    the monitor thread and delay result delivery for subsequently submitted tasks).
+    """
+    uid = "task.unit-cancel"
+    mock_batch_task = MagicMock()
+    mock_batch_task.cancel.return_value = True
+    task_desc = {"uid": uid}
+    backend_v3._task_registry[uid] = {
+        "uid": uid,
+        "description": task_desc,
+        "batch_task": mock_batch_task,
+    }
+    backend_v3._monitored_batches[mock_batch_task.uid] = (mock_batch_task, uid)
+
+    result = await backend_v3.cancel_task(uid)
+
+    # Callback and state must be visible immediately — no yield required
+    assert result is True
+    mock_batch_task.cancel.assert_called_once()
+    backend_v3._callback_func.assert_called_once_with(task_desc, "CANCELED")
+    # Task must be eagerly removed so the monitor loop stops polling
+    assert uid not in backend_v3._task_registry
+    assert mock_batch_task.uid not in backend_v3._monitored_batches
+
+
+@pytest.mark.asyncio
+async def test_v3_cancel_task_returns_false_when_task_completed_before_cancel_lands(backend_v3):
+    """cancel_task returns False when the task was already delivered (registry entry gone).
+
+    Race: the event loop yields inside run_in_executor; _deliver_batch could pop the task
+    from _task_registry before cancel_task resumes. The guard must return False rather than
+    raising KeyError, and must NOT fire the CANCELED callback.
+
+    The test simulates this by patching run_in_executor to pop the registry entry as a
+    side effect — exactly what _deliver_batch does while the executor is in flight.
+    """
+    uid = "task.unit-cancel-race"
+    mock_batch_task = MagicMock()
+    mock_batch_task.cancel.return_value = True
+    task_desc = {"uid": uid}
+    backend_v3._task_registry[uid] = {
+        "uid": uid,
+        "description": task_desc,
+        "batch_task": mock_batch_task,
+    }
+
+    # Simulate _deliver_batch removing the registry entry while run_in_executor is awaited.
+    original_cancel = mock_batch_task.cancel
+
+    def cancel_and_deliver():
+        result = original_cancel()
+        backend_v3._task_registry.pop(uid, None)
+        return result
+
+    mock_batch_task.cancel = cancel_and_deliver
+
+    result = await backend_v3.cancel_task(uid)
+
+    assert result is False
+    backend_v3._callback_func.assert_not_called()
+    assert uid not in backend_v3._task_registry
+
+
+@pytest.mark.asyncio
+async def test_v3_cancel_task_dragon_returns_false_no_callback(backend_v3):
+    """cancel_task does not fire callback when Dragon reports the task cannot be cancelled."""
+    uid = "task.unit-cancel-false"
+    mock_batch_task = MagicMock()
+    mock_batch_task.cancel.return_value = False
+    task_desc = {"uid": uid}
+    backend_v3._task_registry[uid] = {
+        "uid": uid,
+        "description": task_desc,
+        "batch_task": mock_batch_task,
+    }
+
+    result = await backend_v3.cancel_task(uid)
+
+    assert result is False
+    backend_v3._callback_func.assert_not_called()
+    assert uid not in backend_v3._cancelled_tasks
+
+
+@pytest.mark.asyncio
+async def test_v3_cancel_task_dragon_raises_falls_back_to_soft_cancel(backend_v3):
+    """cancel_task falls back to soft-cancel (callback fired, cancelled=True) if Dragon raises."""
+    uid = "task.unit-cancel-exc"
+    mock_batch_task = MagicMock()
+    mock_batch_task.cancel.side_effect = RuntimeError("dragon scheduler unreachable")
+    task_desc = {"uid": uid}
+    backend_v3._task_registry[uid] = {
+        "uid": uid,
+        "description": task_desc,
+        "batch_task": mock_batch_task,
+    }
+    backend_v3._monitored_batches[mock_batch_task.uid] = (mock_batch_task, uid)
+
+    result = await backend_v3.cancel_task(uid)
+
+    assert result is True
+    backend_v3._callback_func.assert_called_once_with(task_desc, "CANCELED")
+    assert uid not in backend_v3._task_registry
+    assert mock_batch_task.uid not in backend_v3._monitored_batches
+
+
+@pytest.mark.asyncio
+async def test_v3_shutdown_calls_join_and_destroy_not_close(backend_v3):
+    """Shutdown() calls batch.join() then batch.destroy(); batch.close() must NOT be called."""
+    await backend_v3.shutdown()
+
+    backend_v3.batch.join.assert_called_once()
+    backend_v3.batch.destroy.assert_called_once()
+    backend_v3.batch.close.assert_not_called()
 
 
 # ============================================================================


### PR DESCRIPTION
Migrate Dragon backend to DragonHPC 0.14.0 and fix cancellation/stdout regressions

DragonHPC 0.14.0 introduced three breaking changes that this commit addresses:

1. Sharded DDict — results are written to a specific DDict shard keyed by manager_idx (SCHEDULER_MANAGER_IDX = -1 maps to shard 0; subnode managers map 1-to-1).  The monitor loop now reads and skips tasks whose manager_idx is still None (the compile has not yet completed).

2. stdout/stderr capture — Dragon 0.14.0 no longer unconditionally sets stdout=Popen.PIPE on ProcessTemplate; needs_output is False by default. Restore prior behavior by injecting stdout=Popen.PIPE at all five ProcessTemplate construction paths (priorities 1–5) for any non-function, non-redirect task.

3. Real task cancellation — Dragon 0.14.0 exposes batch._cancel_task(). cancel_task() now calls batch_task.cancel() via run_in_executor, eagerly removes the task from both _task_registry and _monitored_batches on success, and fires the CANCELED callback inline.  A race guard (pop with None default) handles the window where the monitor delivers the result between the executor return and the registry pop.  Removing canceled tasks from _monitored_batches prevents the monitor thread from making blocking DDict IPC calls for tasks that will never deliver, which was the root cause of the post-cancel monitor stall under workloads with many cancellations.

`session.py` — `TaskStateManager.update_task`: Remove the try/except RuntimeError + `asyncio.get_running_loop()` on-loop detection and the unused asyncio.Lock.  All backends call update_task from the event loop (the monitor thread crosses via call_soon_threadsafe before reaching the callback), so the check was firing 128K+ times per 64K-task workload and always taking the inline branch.  Flatten `_update_task_impl` directly into `update_task` and document the calling contract.

`test_cancel.py`: Change long_running from time.sleep(60) to while True: time.sleep(0.1). Dragon's kill_by_exception (`PyThreadState_SetAsyncExc`) cannot interrupt a C-level sleep until it returns; a Python-level loop responds within one 0.1 s cycle, freeing the function worker promptly after cancellation and allowing subsequent tasks to execute without a 40–60 s stall.