### PR TITLE
telemetry: fix spurious 'Failed to detach context' error on shutdown

### DIFF
--- a/src/rhapsody/telemetry/manager.py
+++ b/src/rhapsody/telemetry/manager.py
@@ -15,6 +15,7 @@ import dataclasses
 import json
 import logging
 import time
+import weakref
 from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -177,12 +178,14 @@ class TelemetryManager:
         self._task_contexts: dict[str, Any] = {}
 
         # Token returned by context.attach() when the session span is activated in start(),
-        # plus the asyncio task that performed the attach. ContextVar tokens can only be
-        # reset from the contextvars.Context they were created in (i.e. the same task), so
-        # stop() skips the detach when it runs in a different task — OTel would otherwise
-        # log a spurious "Failed to detach context" ValueError at shutdown.
+        # plus a weakref to the asyncio task that performed the attach. ContextVar tokens
+        # can only be reset from the contextvars.Context they were created in (i.e. the
+        # same task), so stop() skips the detach when it runs in a different task — OTel
+        # would otherwise log a spurious "Failed to detach context" ValueError at
+        # shutdown. A weakref avoids pinning the starting task's frame for the whole
+        # session lifetime.
         self._session_ctx_token: Any = None
-        self._session_ctx_task: Any = None
+        self._session_ctx_task: weakref.ref | None = None
 
         # Caller-supplied OTel extension points wired into RHAPSODY's internal providers
         # at start() time alongside SpanBuffer / InMemoryMetricReader.
@@ -255,7 +258,8 @@ class TelemetryManager:
         self._session_ctx_token = otel_context.attach(
             trace_mod.set_span_in_context(self._session_span)
         )
-        self._session_ctx_task = asyncio.current_task()
+        _task = asyncio.current_task()
+        self._session_ctx_task = weakref.ref(_task) if _task is not None else None
 
         self._running = True
         self._dispatch_task = asyncio.create_task(self._dispatch_loop(), name="telemetry-dispatch")
@@ -331,8 +335,10 @@ class TelemetryManager:
             # start(); a token reset from any other task raises ValueError inside
             # otel_context.detach(), which OTel catches and logs as an ERROR.
             # Skipping is safe: the attach only ever affected the starting task's
-            # context, and the tracer provider shuts down right below.
-            if asyncio.current_task() is self._session_ctx_task:
+            # context, and the tracer provider shuts down right below. The weakref
+            # resolves to None once the starting task is gone — skip then too.
+            _attached_task = self._session_ctx_task() if self._session_ctx_task else None
+            if _attached_task is not None and asyncio.current_task() is _attached_task:
                 otel_context.detach(self._session_ctx_token)
             self._session_ctx_token = None
             self._session_ctx_task = None

--- a/src/rhapsody/telemetry/manager.py
+++ b/src/rhapsody/telemetry/manager.py
@@ -176,9 +176,13 @@ class TelemetryManager:
         # correct parent span context in the dispatch loop.
         self._task_contexts: dict[str, Any] = {}
 
-        # Token returned by context.attach() when the session span is activated in start().
-        # Stored so it can be properly detached in stop().
+        # Token returned by context.attach() when the session span is activated in start(),
+        # plus the asyncio task that performed the attach. ContextVar tokens can only be
+        # reset from the contextvars.Context they were created in (i.e. the same task), so
+        # stop() skips the detach when it runs in a different task — OTel would otherwise
+        # log a spurious "Failed to detach context" ValueError at shutdown.
         self._session_ctx_token: Any = None
+        self._session_ctx_task: Any = None
 
         # Caller-supplied OTel extension points wired into RHAPSODY's internal providers
         # at start() time alongside SpanBuffer / InMemoryMetricReader.
@@ -251,6 +255,7 @@ class TelemetryManager:
         self._session_ctx_token = otel_context.attach(
             trace_mod.set_span_in_context(self._session_span)
         )
+        self._session_ctx_task = asyncio.current_task()
 
         self._running = True
         self._dispatch_task = asyncio.create_task(self._dispatch_loop(), name="telemetry-dispatch")
@@ -322,8 +327,15 @@ class TelemetryManager:
         from opentelemetry import context as otel_context
 
         if self._session_ctx_token is not None:
-            otel_context.detach(self._session_ctx_token)
+            # Detach only when stop() runs in the task that attached the token in
+            # start(); a token reset from any other task raises ValueError inside
+            # otel_context.detach(), which OTel catches and logs as an ERROR.
+            # Skipping is safe: the attach only ever affected the starting task's
+            # context, and the tracer provider shuts down right below.
+            if asyncio.current_task() is self._session_ctx_task:
+                otel_context.detach(self._session_ctx_token)
             self._session_ctx_token = None
+            self._session_ctx_task = None
 
         if self._meter_provider:
             self._meter_provider.shutdown()


### PR DESCRIPTION
## Summary

`TelemetryManager.stop()` logged a spurious OpenTelemetry error on every otherwise-clean shutdown whenever it ran in a different asyncio task than `start()`:

```
ERROR:    Failed to detach context
...
ValueError: <Token var=<ContextVar name='current_context' ...> was created in a different Context
```

ContextVar tokens can only be reset from the contextvars.Context (i.e. the asyncio task) that created them. Under the ORBIT rhapsody plugin, session init and close are separate requests handled by separate tasks, so the cross-task detach failed every time. The `ValueError` is caught **inside** `opentelemetry.context.detach()` and logged as an ERROR there, so a try/except at the call site cannot silence it — the detach must be skipped instead.

## Fix

Record the attaching task in `start()`; `stop()` detaches only when it runs in that same task, and otherwise just drops the token. Skipping is safe: the attach only ever affected the starting task's context, and the tracer provider shuts down immediately afterwards.

## Verification

- Repro script (start in one task, stop in another): unpatched code logs the exact reported error; patched code shuts down silently.
- `tests/unit/telemetry`: 90 passed with opentelemetry installed (1 failure in `test_emits_resource_update` is pre-existing — fails identically on unpatched `main` in this environment).
- Full unit suite: unchanged vs `main` (remaining failures/errors are missing-dask / Dragon-runtime environment issues, verified pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)