### PR TITLE
docs: add ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,16 @@
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs


### PR DESCRIPTION
Adds `.readthedocs.yaml` (RTD config v2): mkdocs build on ubuntu-24.04 / Python 3.12, installing the package itself plus the `docs` extra so mkdocstrings can import `rhapsody` for API pages.

Verification: config-only change (one new file, no code touched); the `docs` extra covers every plugin referenced in `mkdocs.yml` (gen-files, literate-nav, section-index, mkdocstrings, material). Part of the SINAPSE SDK docs setup — the existing GH Pages deployment is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)