### PR TITLE
version: derive __version__ from package metadata; bump to 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rhapsody-py"
-version = "0.4.0"
+version = "0.4.1"
 description = "Runtime system for executing heterogeneous HPC-AI workflows with dynamic task graphs on high-performance computing infrastructures."
 license = { text = "MIT" }
 authors = [

--- a/src/rhapsody/__init__.py
+++ b/src/rhapsody/__init__.py
@@ -8,6 +8,9 @@ and distributed computing systems.
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
 from .api import AITask
 from .api import BackendError
 from .api import BaseTask
@@ -23,7 +26,10 @@ from .backends import discover_backends
 from .backends import get_backend
 from .logger import enable_logging
 
-__version__ = "0.2.0"
+try:
+    __version__ = _pkg_version("rhapsody-py")
+except PackageNotFoundError:  # uninstalled source tree
+    __version__ = "0.0.0.dev0"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
The 0.4.0 sdist ships `src/rhapsody/__init__.py` with `__version__ = "0.2.0"` while pyproject/PKG-INFO say 0.4.0 (found during conda packaging review, see #83). This derives `__version__` from the installed distribution's metadata — pyproject stays the single source of truth, so the two cannot drift again — with a `0.0.0.dev0` fallback for uninstalled source trees. pyproject bumped to 0.4.1.

Context: the conda-forge submission pins the released sdist; a 0.4.1 release with this fix lets the feedstock ship a package whose reported version is correct. @AymenFJA — over to you for merge, and a 0.4.1 PyPI release after would unblock the clean conda-forge submission.

Verification: `PYTHONPATH=src python -c 'import rhapsody; print(rhapsody.__version__)'` reports the installed dist's version; CI runs the full matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)