### PR TITLE
orbit backend: caller-named broker participant, 'engine' role

### DIFF
--- a/src/rhapsody/backends/execution/orbit.py
+++ b/src/rhapsody/backends/execution/orbit.py
@@ -337,6 +337,9 @@ class OrbitExecutionBackend(BaseBackend):
         rt = EndpointRuntime(
             broker_url=self._broker_url,
             name=self._participant_name or f"rhapsody.{uuid.uuid4().hex[:8]}",
+            # the advertised role defaults to 'consumer', which says nothing.
+            # This participant is the workflow engine's hand-off into ORBIT.
+            role="engine",
         )
         try:
             rt.start(wait=True, timeout=self._start_timeout)

--- a/src/rhapsody/backends/execution/orbit.py
+++ b/src/rhapsody/backends/execution/orbit.py
@@ -94,6 +94,7 @@ class OrbitExecutionBackend(BaseBackend):
         endpoint_name: str | None = None,
         backends: list[str] | None = None,
         name: str = "orbit",
+        participant_name: str | None = None,
         plugin_name: str = _PLUGIN_NAME,
         batch_window: float | None = None,
         batch_limit: int = 1024,
@@ -109,6 +110,7 @@ class OrbitExecutionBackend(BaseBackend):
 
         self.logger = logging.getLogger(__name__)
         self._broker_url = broker_url
+        self._participant_name = participant_name
         self._endpoint_name = endpoint_name
         self._plugin_name = plugin_name
         self._remote_backends = backends or ["dragon_v3"]
@@ -325,12 +327,16 @@ class OrbitExecutionBackend(BaseBackend):
         """
         import uuid
 
-        # A unique name suffix avoids the broker's name-in-use rejection when
-        # several rhapsody clients connect (or one restarts within the
-        # liveness grace window).
+        # The broker shows every runtime as a participant, so an anonymous
+        # `rhapsody.<uuid>` reads as noise in a topology view.  A caller
+        # which knows what this backend is *for* can say so via
+        # ``participant_name`` -- uniqueness is then the caller's contract.
+        # Without one, a unique suffix avoids the broker's name-in-use
+        # rejection when several rhapsody clients connect (or one restarts
+        # within the liveness grace window).
         rt = EndpointRuntime(
             broker_url=self._broker_url,
-            name=f"rhapsody.{uuid.uuid4().hex[:8]}",
+            name=self._participant_name or f"rhapsody.{uuid.uuid4().hex[:8]}",
         )
         try:
             rt.start(wait=True, timeout=self._start_timeout)


### PR DESCRIPTION
Two small changes to how the orbit execution backend presents itself on the broker:

- `participant_name` constructor argument: a caller which knows what the backend is for can name its broker participant (`rhapsody.<session>.<role>`); uniqueness becomes that caller's contract. Unnamed backends keep the `rhapsody.<uuid>` unique suffix and the old behavior exactly.
- the participant advertises `role="engine"` instead of the runtime's say-nothing `consumer` default, so a topology viewer sees what the participant is: the engine side of the compute hand-off.

Motivation: the DTaaS service runs two engines per session (inference/learning); anonymous `rhapsody.<uuid>` participants show up as unexplained noise in the broker topology view. The digital.twins service already passes `participant_name` guarded by a signature check, so this PR is backward- and forward-compatible with it.

Cherry-picked clean onto `main` from the `fix/orbit-participant-name` branch (which is stacked on the flux/partitions work). `tests/unit/test_backend_execution_orbit.py`: 38 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Npyz3Hbnwos12ESsdJ2YU