### PR TITLE
Discovery of Concurrent with ProcessPools

### DIFF
--- a/src/rhapsody/backends/discovery.py
+++ b/src/rhapsody/backends/discovery.py
@@ -192,9 +192,10 @@ def get_backend(backend_name: str, *args: Any, **kwargs: Any) -> BaseBackend:
     backend_class = BackendRegistry.get_backend_class(backend_name)
 
     from concurrent.futures import ProcessPoolExecutor
+
     if backend_name == "concurrent:process_pool":
         return backend_class(ProcessPoolExecutor(), *args, **kwargs)
-    
+
     return backend_class(*args, **kwargs)
 
 

--- a/src/rhapsody/backends/discovery.py
+++ b/src/rhapsody/backends/discovery.py
@@ -73,6 +73,11 @@ class BackendRegistry:
         if "dragon" in cls._backends:
             cls._backends.setdefault("dragon_v3", cls._backends["dragon"])
 
+        # Alias "concurrent:processpool" to concurrent backend with a process
+        # pool instead of default thread pool
+        if "concurrent" in cls._backends:
+            cls._backends["concurrent:process_pool"] = backend_class
+
         cls._initialized = True
 
     @classmethod
@@ -185,6 +190,11 @@ def get_backend(backend_name: str, *args: Any, **kwargs: Any) -> BaseBackend:
         backend = get_backend('radical_pilot')
     """
     backend_class = BackendRegistry.get_backend_class(backend_name)
+
+    from concurrent.futures import ProcessPoolExecutor
+    if(backend_name == "concurrent:process_pool"):
+        return backend_class(ProcessPoolExecutor(), *args, **kwargs)
+    
     return backend_class(*args, **kwargs)
 
 

--- a/src/rhapsody/backends/discovery.py
+++ b/src/rhapsody/backends/discovery.py
@@ -192,7 +192,7 @@ def get_backend(backend_name: str, *args: Any, **kwargs: Any) -> BaseBackend:
     backend_class = BackendRegistry.get_backend_class(backend_name)
 
     from concurrent.futures import ProcessPoolExecutor
-    if(backend_name == "concurrent:process_pool"):
+    if backend_name == "concurrent:process_pool":
         return backend_class(ProcessPoolExecutor(), *args, **kwargs)
     
     return backend_class(*args, **kwargs)


### PR DESCRIPTION
Right now, when referencing the `ConcurrentExecutionBackend` by the "concurrent" tag, it defaults to use the `ThreadPoolExecutor`, as the constructor to the `ConcurrentExecutionBackend` is initialized as empty.

This PR allows for a user to use `concurrent:process_pool` as a tag which automatically fills in the `ConcurrentExecutionBackend` with a `ProcessPoolExecutor`. 

Reasoning: Well, `ThreadPoolExecutor` has limited performance when running cpu-intensive tasks. `ProcessPoolExecutor` allows the user to take advantage of multiple cores for cpu-intensive tasks. This is used specifically in the digital twin use cases where we can't / shouldn't run Dragon on different devices (eg. a Raspberry Pi).